### PR TITLE
Add rustfmt configuration item

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,2 +1,8 @@
 edition = "2018"
 newline_style = "unix"
+# comments
+normalize_comments=true
+wrap_comments=true
+# imports 
+imports_granularity="Crate"
+group_imports="StdExternalCrate"

--- a/examples/async-graphql/main.rs
+++ b/examples/async-graphql/main.rs
@@ -1,10 +1,16 @@
 mod starwars;
 
-use async_graphql::http::{playground_source, GraphQLPlaygroundConfig};
-use async_graphql::{EmptyMutation, EmptySubscription, Request, Response, Schema};
-use poem::middleware::AddData;
-use poem::web::{Data, Html, Json};
-use poem::{get, route, EndpointExt, IntoResponse, Server};
+use async_graphql::{
+    http::{playground_source, GraphQLPlaygroundConfig},
+    EmptyMutation, EmptySubscription, Request, Response, Schema,
+};
+use poem::{
+    get,
+    middleware::AddData,
+    route,
+    web::{Data, Html, Json},
+    EndpointExt, IntoResponse, Server,
+};
 use starwars::{QueryRoot, StarWars, StarWarsSchema};
 
 async fn graphql_handler(schema: Data<StarWarsSchema>, req: Json<Request>) -> Json<Response> {

--- a/examples/async-graphql/starwars/mod.rs
+++ b/examples/async-graphql/starwars/mod.rs
@@ -1,11 +1,11 @@
 mod model;
 
-use async_graphql::{EmptyMutation, EmptySubscription, Schema};
-use model::Episode;
-use slab::Slab;
 use std::collections::HashMap;
 
+use async_graphql::{EmptyMutation, EmptySubscription, Schema};
+use model::Episode;
 pub use model::QueryRoot;
+use slab::Slab;
 
 pub type StarWarsSchema = Schema<QueryRoot, EmptyMutation, EmptySubscription>;
 

--- a/examples/async-graphql/starwars/model.rs
+++ b/examples/async-graphql/starwars/model.rs
@@ -1,6 +1,9 @@
+use async_graphql::{
+    connection::{query, Connection, Edge, EmptyFields},
+    Context, Enum, FieldResult, Interface, Object,
+};
+
 use super::StarWars;
-use async_graphql::connection::{query, Connection, Edge, EmptyFields};
-use async_graphql::{Context, Enum, FieldResult, Interface, Object};
 
 /// One of the films in the Star Wars Trilogy
 #[derive(Enum, Copy, Clone, Eq, PartialEq)]

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -1,5 +1,4 @@
-use poem::web::Path;
-use poem::{get, route};
+use poem::{get, route, web::Path};
 
 async fn hello(Path(name): Path<String>) -> String {
     format!("hello: {}", name)

--- a/src/body.rs
+++ b/src/body.rs
@@ -1,5 +1,7 @@
-use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
 
 use bytes::Bytes;
 use futures_util::Stream;

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -1,6 +1,4 @@
-use std::future::Future;
-use std::marker::PhantomData;
-use std::sync::Arc;
+use std::{future::Future, marker::PhantomData, sync::Arc};
 
 use crate::{FromRequest, IntoResponse, Middleware, Request, Response, Result};
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,9 @@
 //! Some common error types.
 
-use std::convert::Infallible;
-use std::fmt::{self, Debug, Display, Formatter};
+use std::{
+    convert::Infallible,
+    fmt::{self, Debug, Display, Formatter},
+};
 
 use crate::{Body, HeaderName, Response, StatusCode};
 
@@ -22,8 +24,8 @@ macro_rules! define_error {
 
 /// General error.
 ///
-/// In Poem, almost all functions that may return errors return this type, so you don't need to
-/// perform tedious error type conversion.
+/// In Poem, almost all functions that may return errors return this type, so
+/// you don't need to perform tedious error type conversion.
 #[derive(Debug)]
 pub struct Error {
     status: StatusCode,

--- a/src/header/map.rs
+++ b/src/header/map.rs
@@ -1,5 +1,6 @@
-use crate::{HeaderName, HeaderValue};
 use std::iter::FromIterator;
+
+use crate::{HeaderName, HeaderValue};
 
 /// A set of HTTP headers.
 #[derive(Debug, Default, Clone, Eq, PartialEq)]
@@ -14,7 +15,8 @@ impl HeaderMap {
 
     /// Returns the number of headers the map can hold without reallocating.
     ///
-    /// This number is an approximation as certain usage patterns could cause additional allocations before the returned capacity is filled.
+    /// This number is an approximation as certain usage patterns could cause
+    /// additional allocations before the returned capacity is filled.
     pub fn capacity(&self) -> usize {
         self.0.capacity()
     }
@@ -125,7 +127,8 @@ impl HeaderMap {
     /// Remove the entry from the map.
     ///
     /// All values associated with the entry are removed and the first one is
-    /// returned. See [HeaderMap::remove_entry_mult] for an API that returns all values.
+    /// returned. See [HeaderMap::remove_entry_mult] for an API that returns all
+    /// values.
     pub fn remove_entry(&mut self, key: HeaderName) -> Option<HeaderValue> {
         if let http::header::Entry::Occupied(e) = self.0.entry(key.0) {
             let (_, value) = e.remove_entry();

--- a/src/header/name.rs
+++ b/src/header/name.rs
@@ -1,7 +1,8 @@
-use std::str::FromStr;
-
-use std::borrow::Borrow;
-use std::fmt::{Display, Formatter};
+use std::{
+    borrow::Borrow,
+    fmt::{Display, Formatter},
+    str::FromStr,
+};
 
 use crate::error::{Error, ErrorInvalidHeaderName};
 

--- a/src/header/value.rs
+++ b/src/header/value.rs
@@ -1,5 +1,4 @@
-use std::convert::TryFrom;
-use std::str::FromStr;
+use std::{convert::TryFrom, str::FromStr};
 
 use crate::error::{Error, ErrorInvalidHeaderValue, Result};
 
@@ -22,9 +21,11 @@ impl HeaderValue {
         self.0.as_bytes()
     }
 
-    /// Yields a &str slice if the HeaderValue only contains visible ASCII chars.
+    /// Yields a &str slice if the HeaderValue only contains visible ASCII
+    /// chars.
     ///
-    /// This function will perform a scan of the header value, checking all the characters.
+    /// This function will perform a scan of the header value, checking all the
+    /// characters.
     #[inline]
     pub fn to_str(&self) -> Result<&str> {
         self.0
@@ -34,12 +35,14 @@ impl HeaderValue {
 
     /// Convert a static string to a [`HeaderValue`].
     ///
-    /// This function will not perform any copying, however the string is checked to ensure that no
-    /// invalid characters are present. Only visible ASCII characters (32-127) are permitted.
+    /// This function will not perform any copying, however the string is
+    /// checked to ensure that no invalid characters are present. Only
+    /// visible ASCII characters (32-127) are permitted.
     ///
     /// # Panics
     ///
-    /// This function panics if the argument contains invalid header value characters.
+    /// This function panics if the argument contains invalid header value
+    /// characters.
     #[inline]
     pub fn from_static(src: &'static str) -> Self {
         Self(http::header::HeaderValue::from_static(src))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,6 @@
 #![warn(missing_docs)]
 
 pub use http::Extensions;
-
 pub use server::Server;
 
 pub mod error;

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -12,8 +12,9 @@ use crate::Endpoint;
 pub trait Middleware<E> {
     /// New endpoint type.
     ///
-    /// If you don't know what type to use, then you can use [`Box<dyn Endpoint>`], which will bring
-    /// some performance loss, but it is insignificant.
+    /// If you don't know what type to use, then you can use [`Box<dyn
+    /// Endpoint>`], which will bring some performance loss, but it is
+    /// insignificant.
     type Output: Endpoint;
 
     /// Transform the input [EndPoint] to another one.

--- a/src/middleware/strip_prefix.rs
+++ b/src/middleware/strip_prefix.rs
@@ -1,8 +1,10 @@
 use std::sync::Arc;
 
-use crate::error::{Error, ErrorNotFound};
-use crate::uri::Uri;
-use crate::{Endpoint, Middleware, Request, Response, Result};
+use crate::{
+    error::{Error, ErrorNotFound},
+    uri::Uri,
+    Endpoint, Middleware, Request, Response, Result,
+};
 
 /// Middleware for remove path prefix.
 pub struct StripPrefix {

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,8 +1,8 @@
-use std::any::Any;
-use std::convert::TryInto;
+use std::{any::Any, convert::TryInto};
 
-use crate::uri::Uri;
-use crate::{Body, Error, Extensions, HeaderMap, HeaderName, HeaderValue, Method, Result, Version};
+use crate::{
+    uri::Uri, Body, Error, Extensions, HeaderMap, HeaderName, HeaderValue, Method, Result, Version,
+};
 
 struct Parts {
     method: Method,
@@ -182,7 +182,8 @@ impl RequestBuilder {
         }))
     }
 
-    /// Consumes this builder, using the provided body to return a constructed [Request].
+    /// Consumes this builder, using the provided body to return a constructed
+    /// [Request].
     ///
     /// # Errors
     ///

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,5 +1,4 @@
-use std::any::Any;
-use std::convert::TryInto;
+use std::{any::Any, convert::TryInto};
 
 use crate::{
     Body, Error, Extensions, HeaderMap, HeaderName, HeaderValue, Result, StatusCode, Version,
@@ -143,7 +142,8 @@ impl ResponseBuilder {
         }))
     }
 
-    /// Consumes this builder, using the provided body to return a constructed [Response].
+    /// Consumes this builder, using the provided body to return a constructed
+    /// [Response].
     ///
     /// # Errors
     ///

--- a/src/route.rs
+++ b/src/route.rs
@@ -1,10 +1,12 @@
 //! Route object and DSL
 
-use crate::endpoint::{FnHandler, FnHandlerWrapper};
-use crate::error::ErrorNotFound;
-use crate::method::COUNT_METHODS;
-use crate::route_recognizer::Router;
-use crate::{Endpoint, Error, Method, Request, Response, Result};
+use crate::{
+    endpoint::{FnHandler, FnHandlerWrapper},
+    error::ErrorNotFound,
+    method::COUNT_METHODS,
+    route_recognizer::Router,
+    Endpoint, Error, Method, Request, Response, Result,
+};
 
 /// Routing object
 #[derive(Default)]

--- a/src/route_recognizer/mod.rs
+++ b/src/route_recognizer/mod.rs
@@ -1,8 +1,6 @@
 mod nfa;
 
-use std::cmp::Ordering;
-use std::collections::BTreeMap;
-use std::ops::Index;
+use std::{cmp::Ordering, collections::BTreeMap, ops::Index};
 
 use nfa::{CharacterClass, NFA};
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,6 +1,4 @@
-use std::convert::Infallible;
-use std::net::SocketAddr;
-use std::sync::Arc;
+use std::{convert::Infallible, net::SocketAddr, sync::Arc};
 
 use crate::{Endpoint, Request};
 

--- a/src/status_code.rs
+++ b/src/status_code.rs
@@ -1,5 +1,7 @@
-use std::convert::TryFrom;
-use std::fmt::{self, Display, Formatter};
+use std::{
+    convert::TryFrom,
+    fmt::{self, Display, Formatter},
+};
 
 use crate::error::{Error, ErrorInvalidStatusCode};
 

--- a/src/uri/authority.rs
+++ b/src/uri/authority.rs
@@ -1,5 +1,7 @@
-use std::fmt::{self, Display, Formatter};
-use std::str::FromStr;
+use std::{
+    fmt::{self, Display, Formatter},
+    str::FromStr,
+};
 
 use crate::error::{Error, ErrorInvalidUri};
 
@@ -10,11 +12,13 @@ pub struct Authority(pub(crate) http::uri::Authority);
 impl Authority {
     /// Attempt to convert an [`Authority`] from a static string.
     ///
-    /// This function will not perform any copying, and the string will be checked if it is empty or contains an invalid character.
+    /// This function will not perform any copying, and the string will be
+    /// checked if it is empty or contains an invalid character.
     ///
     /// # Panics
     ///
-    /// This function panics if the argument contains invalid characters or is empty.
+    /// This function panics if the argument contains invalid characters or is
+    /// empty.
     #[inline]
     pub fn from_static(src: &'static str) -> Self {
         Authority(http::uri::Authority::from_static(src))

--- a/src/uri/mod.rs
+++ b/src/uri/mod.rs
@@ -5,16 +5,20 @@ mod parts;
 mod path_and_query;
 mod scheme;
 
-use std::fmt::{self, Display, Formatter};
-use std::str::FromStr;
+use std::{
+    fmt::{self, Display, Formatter},
+    str::FromStr,
+};
 
 pub use authority::Authority;
 pub use parts::Parts;
 pub use path_and_query::PathAndQuery;
 pub use scheme::Scheme;
 
-use crate::error::{Error, ErrorInvalidUri};
-use crate::Result;
+use crate::{
+    error::{Error, ErrorInvalidUri},
+    Result,
+};
 
 /// The URI component of a request.
 #[derive(Debug, Clone, Hash, Default)]

--- a/src/uri/path_and_query.rs
+++ b/src/uri/path_and_query.rs
@@ -1,5 +1,7 @@
-use std::fmt::{self, Display, Formatter};
-use std::str::FromStr;
+use std::{
+    fmt::{self, Display, Formatter},
+    str::FromStr,
+};
 
 use crate::error::{Error, ErrorInvalidUri};
 
@@ -10,7 +12,8 @@ pub struct PathAndQuery(pub(crate) http::uri::PathAndQuery);
 impl PathAndQuery {
     /// Convert a [`PathAndQuery`] from a static string.
     ///
-    /// This function will not perform any copying, however the string is checked to ensure that it is valid.
+    /// This function will not perform any copying, however the string is
+    /// checked to ensure that it is valid.
     ///
     /// # Panics
     ///

--- a/src/web/form.rs
+++ b/src/web/form.rs
@@ -2,15 +2,18 @@ use std::ops::{Deref, DerefMut};
 
 use serde::de::DeserializeOwned;
 
-use crate::error::ErrorInvalidFormContentType;
-use crate::{Error, FromRequest, HeaderName, HeaderValue, Method, Request, Result};
+use crate::{
+    error::ErrorInvalidFormContentType, Error, FromRequest, HeaderName, HeaderValue, Method,
+    Request, Result,
+};
 
 /// An extractor that can deserialize some type from query string or body.
 ///
-/// If the method is not `GET`, the query parameters will be parsed from the body, otherwise it is like [`Query`](crate::web::Query).
+/// If the method is not `GET`, the query parameters will be parsed from the
+/// body, otherwise it is like [`Query`](crate::web::Query).
 ///
-/// If the `Content-Type` is not `application/x-www-form-urlencoded`, then a `Bad Request` response
-/// will be returned.
+/// If the `Content-Type` is not `application/x-www-form-urlencoded`, then a
+/// `Bad Request` response will be returned.
 pub struct Form<T>(pub T);
 
 impl<T> Deref for Form<T> {

--- a/src/web/json.rs
+++ b/src/web/json.rs
@@ -1,14 +1,15 @@
-use serde::de::DeserializeOwned;
 use std::ops::{Deref, DerefMut};
 
+use serde::{de::DeserializeOwned, Serialize};
+
 use crate::{Error, FromRequest, HeaderName, IntoResponse, Request, Response, Result};
-use serde::Serialize;
 
 /// JSON extractor and response.
 ///
 /// # Extractor
 ///
-/// To extract the specified type of JSON from the body, `T` must implement [`serde::Deserialize`].
+/// To extract the specified type of JSON from the body, `T` must implement
+/// [`serde::Deserialize`].
 ///
 /// ```
 /// use serde::Deserialize;
@@ -26,7 +27,8 @@ use serde::Serialize;
 ///
 /// # Response
 ///
-/// To serialize the specified type to JSON, `T` must implement [`serde::Serialize`].
+/// To serialize the specified type to JSON, `T` must implement
+/// [`serde::Serialize`].
 ///
 /// ```
 /// use serde::Serialize;

--- a/src/web/mod.rs
+++ b/src/web/mod.rs
@@ -10,7 +10,6 @@ mod query;
 use std::convert::Infallible;
 
 use bytes::Bytes;
-
 pub use data::Data;
 pub use form::Form;
 pub use json::Json;

--- a/src/web/multipart.rs
+++ b/src/web/multipart.rs
@@ -5,7 +5,8 @@ use tokio::io::{AsyncRead, AsyncReadExt};
 
 use crate::{Error, FromRequest, HeaderName, Request, Result};
 
-/// An extractor that parses `multipart/form-data` requests commonly used with file uploads.
+/// An extractor that parses `multipart/form-data` requests commonly used with
+/// file uploads.
 ///
 /// # Example
 ///

--- a/src/web/path/de.rs
+++ b/src/web/path/de.rs
@@ -543,9 +543,11 @@ impl<'de> SeqAccess<'de> for SeqDeserializer<'de> {
 #[cfg(test)]
 #[allow(clippy::float_cmp)]
 mod tests {
-    use super::*;
-    use serde::Deserialize;
     use std::collections::HashMap;
+
+    use serde::Deserialize;
+
+    use super::*;
 
     #[derive(Debug, Deserialize, Eq, PartialEq)]
     enum MyEnum {

--- a/src/web/path/mod.rs
+++ b/src/web/path/mod.rs
@@ -4,11 +4,14 @@ use std::ops::{Deref, DerefMut};
 
 use serde::de::DeserializeOwned;
 
-use crate::error::{ErrorInvalidPathParams, ErrorMissingRouteParams};
-use crate::route_recognizer::Params;
-use crate::{Error, FromRequest, Request, Result};
+use crate::{
+    error::{ErrorInvalidPathParams, ErrorMissingRouteParams},
+    route_recognizer::Params,
+    Error, FromRequest, Request, Result,
+};
 
-/// An extractor that will get captures from the URL and parse them using `serde`.
+/// An extractor that will get captures from the URL and parse them using
+/// `serde`.
 ///
 /// # Example
 ///

--- a/src/websocket/extractor.rs
+++ b/src/websocket/extractor.rs
@@ -1,14 +1,12 @@
-use std::borrow::Cow;
-use std::future::Future;
+use std::{borrow::Cow, future::Future};
 
 use hyper::upgrade::OnUpgrade;
 use tokio_tungstenite::tungstenite::protocol::Role;
 
 use super::WebSocketStream;
-use crate::websocket::utils::sign;
 use crate::{
-    Body, Error, FromRequest, HeaderName, HeaderValue, IntoResponse, Method, Request, Response,
-    Result, StatusCode,
+    websocket::utils::sign, Body, Error, FromRequest, HeaderName, HeaderValue, IntoResponse,
+    Method, Request, Response, Result, StatusCode,
 };
 
 /// An extractor that can accept websocket connections.
@@ -72,8 +70,8 @@ impl WebSocket {
     /// Set the known protocols.
     ///
     /// If the protocol name specified by `Sec-WebSocket-Protocol` header
-    /// to match any of them, the upgrade response will include `Sec-WebSocket-Protocol` header and
-    /// return the protocol name.
+    /// to match any of them, the upgrade response will include
+    /// `Sec-WebSocket-Protocol` header and return the protocol name.
     ///
     /// ```
     /// use futures_util::{StreamExt, SinkExt};
@@ -103,9 +101,11 @@ impl WebSocket {
         self
     }
 
-    /// Finalize upgrading the connection and call the provided `callback` with the stream.
+    /// Finalize upgrading the connection and call the provided `callback` with
+    /// the stream.
     ///
-    /// Note that the return value of this function must be returned from the handler.
+    /// Note that the return value of this function must be returned from the
+    /// handler.
     pub fn on_upgrade<F, Fut>(self, callback: F) -> impl IntoResponse
     where
         F: FnOnce(WebSocketStream) -> Fut + Send + 'static,

--- a/src/websocket/message.rs
+++ b/src/websocket/message.rs
@@ -1,4 +1,5 @@
-/// Status code used to indicate why an endpoint is closing the WebSocket connection.
+/// Status code used to indicate why an endpoint is closing the WebSocket
+/// connection.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum CloseCode {
     /// Indicates a normal closure, meaning that the purpose for
@@ -46,12 +47,13 @@ pub enum CloseCode {
     /// it encountered an unexpected condition that prevented it from
     /// fulfilling the request.
     Error,
-    /// Indicates that the server is restarting. A client may choose to reconnect,
-    /// and if it does, it should use a randomized delay of 5-30 seconds between attempts.
+    /// Indicates that the server is restarting. A client may choose to
+    /// reconnect, and if it does, it should use a randomized delay of 5-30
+    /// seconds between attempts.
     Restart,
-    /// Indicates that the server is overloaded and the client should either connect
-    /// to a different IP (when multiple targets exist), or reconnect to the same IP
-    /// when a user has performed an action.
+    /// Indicates that the server is overloaded and the client should either
+    /// connect to a different IP (when multiple targets exist), or
+    /// reconnect to the same IP when a user has performed an action.
     Again,
     /// Code reserved for the future.
     Reserved(u16),

--- a/src/websocket/stream.rs
+++ b/src/websocket/stream.rs
@@ -1,14 +1,16 @@
-use std::io::{Error as IoError, Result as IoResult};
-use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::{
+    io::{Error as IoError, Result as IoResult},
+    pin::Pin,
+    task::{Context, Poll},
+};
 
 use futures_util::{Sink, SinkExt, Stream, StreamExt};
 use hyper::upgrade::Upgraded;
 
-use super::utils::tungstenite_error_to_io_error;
-use super::Message;
+use super::{utils::tungstenite_error_to_io_error, Message};
 
-/// A `WebSocket` stream, which implements [`Stream<Message>`] and [`Sink<Message>`].
+/// A `WebSocket` stream, which implements [`Stream<Message>`] and
+/// [`Sink<Message>`].
 pub struct WebSocketStream {
     inner: tokio_tungstenite::WebSocketStream<Upgraded>,
 }

--- a/src/websocket/utils.rs
+++ b/src/websocket/utils.rs
@@ -1,5 +1,7 @@
-use std::convert::TryInto;
-use std::io::{Error as IoError, ErrorKind};
+use std::{
+    convert::TryInto,
+    io::{Error as IoError, ErrorKind},
+};
 
 use sha1::Sha1;
 use tokio_tungstenite::tungstenite::protocol::CloseFrame;


### PR DESCRIPTION
Add the following rustfmt configuration item：

```toml
# comments
normalize_comments=true
wrap_comments=true
# imports 
imports_granularity="Crate"
group_imports="StdExternalCrate"
```

For controlling comment width and automatic line feeds, as well as automatic grouping of imported modules.

For details：[Files changed](https://github.com/poem-web/poem/pull/3/files)

```
> cargo +nightly fmt
```