### PR TITLE
Fix CORS Preflight response

### DIFF
--- a/poem/src/middleware/cors.rs
+++ b/poem/src/middleware/cors.rs
@@ -144,7 +144,7 @@ impl<E> CorsImpl<E> {
         let mut builder = Response::builder();
 
         for origin in &self.config.allow_origins {
-            builder = builder.header(header::ORIGIN, origin.clone());
+            builder = builder.header(header::ACCESS_CONTROL_ALLOW_ORIGIN, origin.clone());
         }
 
         for method in &self.config.allow_methods {


### PR DESCRIPTION
Hello! Really liking this library so far, especially the OpenAPI integration. I found a small bug in the CORS middleware:

Allowed origins should be returned in Access-Control-Allow-Origin for preflight responses to work correctly.