### PR TITLE
Fix lints clippy::semicolon-if-nothing-returned and clippy::trivially…

### DIFF
--- a/examples/openapi/auth/src/main.rs
+++ b/examples/openapi/auth/src/main.rs
@@ -117,7 +117,7 @@ async fn oauth_token_url_proxy(req: &poem::Request, body: poem::Body) -> Result<
 #[tokio::main]
 async fn main() -> Result<(), std::io::Error> {
     if std::env::var_os("RUST_LOG").is_none() {
-        std::env::set_var("RUST_LOG", "poem=debug")
+        std::env::set_var("RUST_LOG", "poem=debug");
     }
     tracing_subscriber::fmt::init();
 

--- a/examples/openapi/combined-apis/src/main.rs
+++ b/examples/openapi/combined-apis/src/main.rs
@@ -34,7 +34,7 @@ impl Api3 {
 #[tokio::main]
 async fn main() -> Result<(), std::io::Error> {
     if std::env::var_os("RUST_LOG").is_none() {
-        std::env::set_var("RUST_LOG", "poem=debug")
+        std::env::set_var("RUST_LOG", "poem=debug");
     }
     tracing_subscriber::fmt::init();
 

--- a/examples/openapi/hello-world/src/main.rs
+++ b/examples/openapi/hello-world/src/main.rs
@@ -20,7 +20,7 @@ impl Api {
 #[tokio::main]
 async fn main() -> Result<(), std::io::Error> {
     if std::env::var_os("RUST_LOG").is_none() {
-        std::env::set_var("RUST_LOG", "poem=debug")
+        std::env::set_var("RUST_LOG", "poem=debug");
     }
     tracing_subscriber::fmt::init();
 

--- a/examples/openapi/oneof/src/main.rs
+++ b/examples/openapi/oneof/src/main.rs
@@ -32,7 +32,7 @@ impl Api {
 #[tokio::main]
 async fn main() -> Result<(), std::io::Error> {
     if std::env::var_os("RUST_LOG").is_none() {
-        std::env::set_var("RUST_LOG", "poem=debug")
+        std::env::set_var("RUST_LOG", "poem=debug");
     }
     tracing_subscriber::fmt::init();
 

--- a/examples/openapi/poem-extractor/src/main.rs
+++ b/examples/openapi/poem-extractor/src/main.rs
@@ -14,7 +14,7 @@ impl Api {
 #[tokio::main]
 async fn main() -> Result<(), std::io::Error> {
     if std::env::var_os("RUST_LOG").is_none() {
-        std::env::set_var("RUST_LOG", "poem=debug")
+        std::env::set_var("RUST_LOG", "poem=debug");
     }
     tracing_subscriber::fmt::init();
 

--- a/examples/openapi/poem-middleware/src/main.rs
+++ b/examples/openapi/poem-middleware/src/main.rs
@@ -18,7 +18,7 @@ fn set_header(ep: impl Endpoint) -> impl Endpoint {
 #[tokio::main]
 async fn main() -> Result<(), std::io::Error> {
     if std::env::var_os("RUST_LOG").is_none() {
-        std::env::set_var("RUST_LOG", "poem=debug")
+        std::env::set_var("RUST_LOG", "poem=debug");
     }
     tracing_subscriber::fmt::init();
 

--- a/examples/openapi/upload/src/main.rs
+++ b/examples/openapi/upload/src/main.rs
@@ -85,7 +85,7 @@ impl Api {
 #[tokio::main]
 async fn main() -> Result<(), std::io::Error> {
     if std::env::var_os("RUST_LOG").is_none() {
-        std::env::set_var("RUST_LOG", "poem=debug")
+        std::env::set_var("RUST_LOG", "poem=debug");
     }
     tracing_subscriber::fmt::init();
 

--- a/examples/openapi/users-crud/src/main.rs
+++ b/examples/openapi/users-crud/src/main.rs
@@ -144,7 +144,7 @@ impl Api {
 #[tokio::main]
 async fn main() -> Result<(), std::io::Error> {
     if std::env::var_os("RUST_LOG").is_none() {
-        std::env::set_var("RUST_LOG", "poem=debug")
+        std::env::set_var("RUST_LOG", "poem=debug");
     }
     tracing_subscriber::fmt::init();
 

--- a/examples/poem/async-graphql/src/main.rs
+++ b/examples/poem/async-graphql/src/main.rs
@@ -27,7 +27,7 @@ fn graphql_playground() -> impl IntoResponse {
 #[tokio::main]
 async fn main() -> Result<(), std::io::Error> {
     if std::env::var_os("RUST_LOG").is_none() {
-        std::env::set_var("RUST_LOG", "poem=debug")
+        std::env::set_var("RUST_LOG", "poem=debug");
     }
     tracing_subscriber::fmt::init();
 

--- a/examples/poem/async-graphql/src/starwars/mod.rs
+++ b/examples/poem/async-graphql/src/starwars/mod.rs
@@ -123,18 +123,18 @@ impl StarWars {
     }
 
     pub fn human(&self, id: &str) -> Option<usize> {
-        self.human_data.get(id).cloned()
+        self.human_data.get(id).copied()
     }
 
     pub fn droid(&self, id: &str) -> Option<usize> {
-        self.droid_data.get(id).cloned()
+        self.droid_data.get(id).copied()
     }
 
     pub fn humans(&self) -> Vec<usize> {
-        self.human_data.values().cloned().collect()
+        self.human_data.values().copied().collect()
     }
 
     pub fn droids(&self) -> Vec<usize> {
-        self.droid_data.values().cloned().collect()
+        self.droid_data.values().copied().collect()
     }
 }

--- a/examples/poem/combined-listeners/src/main.rs
+++ b/examples/poem/combined-listeners/src/main.rs
@@ -14,7 +14,7 @@ fn hello() -> impl IntoResponse {
 #[tokio::main]
 async fn main() -> Result<(), std::io::Error> {
     if std::env::var_os("RUST_LOG").is_none() {
-        std::env::set_var("RUST_LOG", "poem=debug")
+        std::env::set_var("RUST_LOG", "poem=debug");
     }
     tracing_subscriber::fmt::init();
 

--- a/examples/poem/cookie-session/src/main.rs
+++ b/examples/poem/cookie-session/src/main.rs
@@ -56,7 +56,7 @@ async fn init_session(store: &Data<&MemoryStore>, cookie_jar: &CookieJar) {
 #[tokio::main]
 async fn main() -> Result<(), std::io::Error> {
     if std::env::var_os("RUST_LOG").is_none() {
-        std::env::set_var("RUST_LOG", "poem=debug")
+        std::env::set_var("RUST_LOG", "poem=debug");
     }
     tracing_subscriber::fmt::init();
 

--- a/examples/poem/custom-error/src/main.rs
+++ b/examples/poem/custom-error/src/main.rs
@@ -27,7 +27,7 @@ fn hello() -> Result<String, CustomError> {
 #[tokio::main]
 async fn main() -> Result<(), std::io::Error> {
     if std::env::var_os("RUST_LOG").is_none() {
-        std::env::set_var("RUST_LOG", "poem=debug")
+        std::env::set_var("RUST_LOG", "poem=debug");
     }
     tracing_subscriber::fmt::init();
 

--- a/examples/poem/graceful-shutdown/src/main.rs
+++ b/examples/poem/graceful-shutdown/src/main.rs
@@ -41,7 +41,7 @@ fn event() -> SSE {
 #[tokio::main]
 async fn main() -> Result<(), std::io::Error> {
     if std::env::var_os("RUST_LOG").is_none() {
-        std::env::set_var("RUST_LOG", "poem=debug")
+        std::env::set_var("RUST_LOG", "poem=debug");
     }
     tracing_subscriber::fmt::init();
 

--- a/examples/poem/handling-404/src/main.rs
+++ b/examples/poem/handling-404/src/main.rs
@@ -11,7 +11,7 @@ fn hello(Path(name): Path<String>) -> String {
 #[tokio::main]
 async fn main() -> Result<(), std::io::Error> {
     if std::env::var_os("RUST_LOG").is_none() {
-        std::env::set_var("RUST_LOG", "poem=debug")
+        std::env::set_var("RUST_LOG", "poem=debug");
     }
     tracing_subscriber::fmt::init();
 

--- a/examples/poem/hello-world/src/main.rs
+++ b/examples/poem/hello-world/src/main.rs
@@ -8,7 +8,7 @@ fn hello(Path(name): Path<String>) -> String {
 #[tokio::main]
 async fn main() -> Result<(), std::io::Error> {
     if std::env::var_os("RUST_LOG").is_none() {
-        std::env::set_var("RUST_LOG", "poem=debug")
+        std::env::set_var("RUST_LOG", "poem=debug");
     }
     tracing_subscriber::fmt::init();
 

--- a/examples/poem/json/src/main.rs
+++ b/examples/poem/json/src/main.rs
@@ -17,7 +17,7 @@ fn hello(req: Json<CreateSomething>) -> Json<serde_json::Value> {
 #[tokio::main]
 async fn main() -> Result<(), std::io::Error> {
     if std::env::var_os("RUST_LOG").is_none() {
-        std::env::set_var("RUST_LOG", "poem=debug")
+        std::env::set_var("RUST_LOG", "poem=debug");
     }
     tracing_subscriber::fmt::init();
 

--- a/examples/poem/lambda-hello-world/src/main.rs
+++ b/examples/poem/lambda-hello-world/src/main.rs
@@ -9,7 +9,7 @@ fn hello(Path(name): Path<String>) -> String {
 #[tokio::main]
 async fn main() -> Result<(), Error> {
     if std::env::var_os("RUST_LOG").is_none() {
-        std::env::set_var("RUST_LOG", "poem=debug")
+        std::env::set_var("RUST_LOG", "poem=debug");
     }
     tracing_subscriber::fmt::init();
 

--- a/examples/poem/middleware/src/main.rs
+++ b/examples/poem/middleware/src/main.rs
@@ -39,7 +39,7 @@ fn index() -> String {
 #[tokio::main]
 async fn main() -> Result<(), std::io::Error> {
     if std::env::var_os("RUST_LOG").is_none() {
-        std::env::set_var("RUST_LOG", "poem=debug")
+        std::env::set_var("RUST_LOG", "poem=debug");
     }
     tracing_subscriber::fmt::init();
 

--- a/examples/poem/mongodb/src/main.rs
+++ b/examples/poem/mongodb/src/main.rs
@@ -58,7 +58,7 @@ async fn create_user(
 #[tokio::main]
 async fn main() -> io::Result<()> {
     if std::env::var_os("RUST_LOG").is_none() {
-        std::env::set_var("RUST_LOG", "poem=debug")
+        std::env::set_var("RUST_LOG", "poem=debug");
     }
     tracing_subscriber::fmt::init();
 

--- a/examples/poem/sse/src/main.rs
+++ b/examples/poem/sse/src/main.rs
@@ -41,7 +41,7 @@ fn event() -> SSE {
 #[tokio::main]
 async fn main() -> Result<(), std::io::Error> {
     if std::env::var_os("RUST_LOG").is_none() {
-        std::env::set_var("RUST_LOG", "poem=debug")
+        std::env::set_var("RUST_LOG", "poem=debug");
     }
     tracing_subscriber::fmt::init();
 

--- a/examples/poem/static-files/src/main.rs
+++ b/examples/poem/static-files/src/main.rs
@@ -3,7 +3,7 @@ use poem::{listener::TcpListener, route, service::Files, Server};
 #[tokio::main]
 async fn main() -> Result<(), std::io::Error> {
     if std::env::var_os("RUST_LOG").is_none() {
-        std::env::set_var("RUST_LOG", "poem=debug")
+        std::env::set_var("RUST_LOG", "poem=debug");
     }
     tracing_subscriber::fmt::init();
 

--- a/examples/poem/tls/src/main.rs
+++ b/examples/poem/tls/src/main.rs
@@ -71,7 +71,7 @@ fn index() -> &'static str {
 #[tokio::main]
 async fn main() -> Result<(), std::io::Error> {
     if std::env::var_os("RUST_LOG").is_none() {
-        std::env::set_var("RUST_LOG", "poem=debug")
+        std::env::set_var("RUST_LOG", "poem=debug");
     }
     tracing_subscriber::fmt::init();
 

--- a/examples/poem/tonic/src/main.rs
+++ b/examples/poem/tonic/src/main.rs
@@ -29,7 +29,7 @@ impl Greeter for MyGreeter {
 #[tokio::main]
 async fn main() -> Result<(), std::io::Error> {
     if std::env::var_os("RUST_LOG").is_none() {
-        std::env::set_var("RUST_LOG", "poem=debug")
+        std::env::set_var("RUST_LOG", "poem=debug");
     }
     tracing_subscriber::fmt::init();
 

--- a/examples/poem/tower-layer/src/main.rs
+++ b/examples/poem/tower-layer/src/main.rs
@@ -13,7 +13,7 @@ fn hello() -> &'static str {
 #[tokio::main]
 async fn main() -> Result<(), std::io::Error> {
     if std::env::var_os("RUST_LOG").is_none() {
-        std::env::set_var("RUST_LOG", "poem=debug")
+        std::env::set_var("RUST_LOG", "poem=debug");
     }
     tracing_subscriber::fmt::init();
 

--- a/examples/poem/unix-socket/src/main.rs
+++ b/examples/poem/unix-socket/src/main.rs
@@ -11,7 +11,7 @@ async fn main() -> Result<(), std::io::Error> {
     }
 
     if std::env::var_os("RUST_LOG").is_none() {
-        std::env::set_var("RUST_LOG", "poem=debug")
+        std::env::set_var("RUST_LOG", "poem=debug");
     }
     tracing_subscriber::fmt::init();
 

--- a/examples/poem/upload/src/main.rs
+++ b/examples/poem/upload/src/main.rs
@@ -19,7 +19,7 @@ async fn index(mut multipart: Multipart) {
 #[tokio::main]
 async fn main() -> Result<(), std::io::Error> {
     if std::env::var_os("RUST_LOG").is_none() {
-        std::env::set_var("RUST_LOG", "poem=debug")
+        std::env::set_var("RUST_LOG", "poem=debug");
     }
     tracing_subscriber::fmt::init();
 

--- a/examples/poem/websocket-chat/src/main.rs
+++ b/examples/poem/websocket-chat/src/main.rs
@@ -95,7 +95,7 @@ fn ws(
 #[tokio::main]
 async fn main() -> Result<(), std::io::Error> {
     if std::env::var_os("RUST_LOG").is_none() {
-        std::env::set_var("RUST_LOG", "poem=debug")
+        std::env::set_var("RUST_LOG", "poem=debug");
     }
     tracing_subscriber::fmt::init();
 

--- a/poem-openapi-derive/src/common_args.rs
+++ b/poem-openapi-derive/src/common_args.rs
@@ -21,7 +21,7 @@ pub(crate) enum RenameRule {
 }
 
 impl RenameRule {
-    pub(crate) fn rename(&self, name: impl AsRef<str>) -> String {
+    pub(crate) fn rename(self, name: impl AsRef<str>) -> String {
         match self {
             Self::Lower => name.as_ref().to_lowercase(),
             Self::Upper => name.as_ref().to_uppercase(),
@@ -43,7 +43,7 @@ pub(crate) enum RenameTarget {
 }
 
 impl RenameTarget {
-    pub(crate) fn rule(&self) -> RenameRule {
+    pub(crate) fn rule(self) -> RenameRule {
         match self {
             RenameTarget::Type => RenameRule::Pascal,
             RenameTarget::EnumItem => RenameRule::ScreamingSnake,
@@ -53,7 +53,7 @@ impl RenameTarget {
         }
     }
 
-    pub(crate) fn rename(&self, name: impl AsRef<str>) -> String {
+    pub(crate) fn rename(self, name: impl AsRef<str>) -> String {
         self.rule().rename(name)
     }
 }

--- a/poem-openapi/src/payload/json.rs
+++ b/poem-openapi/src/payload/json.rs
@@ -21,7 +21,7 @@ impl<T: Type> Payload for Json<T> {
 
     #[allow(unused_variables)]
     fn register(registry: &mut Registry) {
-        T::register(registry)
+        T::register(registry);
     }
 }
 

--- a/poem-openapi/src/registry/mod.rs
+++ b/poem-openapi/src/registry/mod.rs
@@ -13,8 +13,9 @@ use serde_json::Value;
 
 use crate::types::TypeName;
 
+#[allow(clippy::trivially_copy_pass_by_ref)]
 #[inline]
-fn is_false(value: &bool) -> bool {
+const fn is_false(value: &bool) -> bool {
     !*value
 }
 


### PR DESCRIPTION
[trivially_copy_pass_by_ref lint](https://rust-lang.github.io/rust-clippy/master/index.html#trivially_copy_pass_by_ref)

On x86_64 machine pointer size is 8 byte, if self is a one byte enum, pass by value is faster than pass by reference

This lint is one of clippy::pedantic group

> cargo clippy -- -Wclippy::pedantic 2>&1 | less

```
warning: this argument (1 byte) is passed by reference, but would be more efficient if passed by value (limit: 8 byte)
  --> poem-openapi-derive/src/common_args.rs:24:26
   |
24 |     pub(crate) fn rename(&self, name: impl AsRef<str>) -> String {
   |                          ^^^^^ help: consider passing by value instead: `self`
   |
   = note: requested on the command line with `-W clippy::trivially-copy-pass-by-ref`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#trivially_copy_pass_by_ref
```

[semicolon-if-nothing-returned lint](https://rust-lang.github.io/rust-clippy/master/index.html#semicolon_if_nothing_returned)

```
warning: consider adding a `;` to the last statement for consistent formatting
  --> examples/openapi/poem-middleware/src/main.rs:21:9
   |
21 |         std::env::set_var("RUST_LOG", "poem=debug")
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: add a `;` here: `std::env::set_var("RUST_LOG", "poem=debug");`
   |
   = note: requested on the command line with `-W clippy::semicolon-if-nothing-returned`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#semicolon_if_nothing_returned
```