### PR TITLE
fix cargo test --package poem compile failed and clippy::large_enum_v…

### DIFF
--- a/poem-openapi-derive/src/multipart.rs
+++ b/poem-openapi-derive/src/multipart.rs
@@ -225,7 +225,7 @@ pub(crate) fn generate(args: DeriveInput) -> GeneratorResult<TokenStream> {
                     properties: ::std::vec![#(#meta_fields),*],
                     ..#crate_name::registry::MetaSchema::new("object")
                 };
-                #crate_name::registry::MetaSchemaRef::Inline(schema)
+                #crate_name::registry::MetaSchemaRef::Inline(Box::new(schema))
             }
 
             fn register(registry: &mut #crate_name::registry::Registry) {

--- a/poem-openapi-derive/src/oneof.rs
+++ b/poem-openapi-derive/src/oneof.rs
@@ -100,18 +100,18 @@ pub(crate) fn generate(args: DeriveInput) -> GeneratorResult<TokenStream> {
             type ValueType = Self;
 
             fn schema_ref() -> #crate_name::registry::MetaSchemaRef {
-                #crate_name::registry::MetaSchemaRef::Inline(#crate_name::registry::MetaSchema {
+                #crate_name::registry::MetaSchemaRef::Inline(Box::new(#crate_name::registry::MetaSchema {
                     one_of: ::std::vec![#(<#types as #crate_name::types::Type>::schema_ref()),*],
-                    properties: ::std::vec![(#property_name, #crate_name::registry::MetaSchemaRef::Inline(#crate_name::registry::MetaSchema {
+                    properties: ::std::vec![(#property_name, #crate_name::registry::MetaSchemaRef::Inline(Box::new(#crate_name::registry::MetaSchema {
                         enum_items: ::std::vec![#(::std::convert::Into::into(#names)),*],
                         ..#crate_name::registry::MetaSchema::new("string")
-                    }))],
+                    })))],
                     discriminator: ::std::option::Option::Some(#crate_name::registry::MetaDiscriminatorObject {
                         property_name: #property_name,
                         mapping: ::std::vec![#(#mapping),*],
                     }),
                     ..#crate_name::registry::MetaSchema::new("object")
-                })
+                }))
             }
 
             fn register(registry: &mut #crate_name::registry::Registry) {

--- a/poem-openapi/CHANGELOG.md
+++ b/poem-openapi/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- [[#57]] Add `prefix_path` and `tag` attributes for `#[OpenApi]`
+
+### Breaking Changes
+
+- [[#59]] `MetaSchemaRef::Inline(MetaSchema)` -> `MetaSchemaRef::Inline(Box<MetaSchema>)`
+
 ## [1.0.2] 2021-10-11
 
 - Add `write_only` and `read_only` attributes for object fields.

--- a/poem-openapi/src/payload/binary.rs
+++ b/poem-openapi/src/payload/binary.rs
@@ -14,10 +14,10 @@ impl<T> Payload for Binary<T> {
     const CONTENT_TYPE: &'static str = "application/octet-stream";
 
     fn schema_ref() -> MetaSchemaRef {
-        MetaSchemaRef::Inline(MetaSchema {
+        MetaSchemaRef::Inline(Box::new(MetaSchema {
             format: Some("binary"),
             ..MetaSchema::new("string")
-        })
+        }))
     }
 }
 

--- a/poem-openapi/src/registry/mod.rs
+++ b/poem-openapi/src/registry/mod.rs
@@ -247,7 +247,7 @@ impl From<TypeName> for MetaSchema {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum MetaSchemaRef {
-    Inline(MetaSchema),
+    Inline(Box<MetaSchema>),
     Reference(&'static str),
 }
 
@@ -268,16 +268,19 @@ impl MetaSchemaRef {
 
     pub fn merge(self, other: MetaSchema) -> Self {
         match self {
-            MetaSchemaRef::Inline(schema) => MetaSchemaRef::Inline(schema.merge(other)),
+            MetaSchemaRef::Inline(schema) => MetaSchemaRef::Inline(Box::new(schema.merge(other))),
             MetaSchemaRef::Reference(name) => {
                 let other = MetaSchema::ANY.merge(other);
                 if other.is_empty() {
                     MetaSchemaRef::Reference(name)
                 } else {
-                    MetaSchemaRef::Inline(MetaSchema {
-                        all_of: vec![MetaSchemaRef::Reference(name), MetaSchemaRef::Inline(other)],
+                    MetaSchemaRef::Inline(Box::new(MetaSchema {
+                        all_of: vec![
+                            MetaSchemaRef::Reference(name),
+                            MetaSchemaRef::Inline(Box::new(other)),
+                        ],
                         ..MetaSchema::ANY
-                    })
+                    }))
                 }
             }
         }

--- a/poem-openapi/src/types/base64_type.rs
+++ b/poem-openapi/src/types/base64_type.rs
@@ -17,7 +17,7 @@ impl Type for Base64 {
     };
 
     fn schema_ref() -> MetaSchemaRef {
-        MetaSchemaRef::Inline(Self::NAME.into())
+        MetaSchemaRef::Inline(Box::new(Self::NAME.into()))
     }
 
     impl_value_type!();

--- a/poem-openapi/src/types/binary.rs
+++ b/poem-openapi/src/types/binary.rs
@@ -16,7 +16,7 @@ impl Type for Binary {
     };
 
     fn schema_ref() -> MetaSchemaRef {
-        MetaSchemaRef::Inline(Self::NAME.into())
+        MetaSchemaRef::Inline(Box::new(Self::NAME.into()))
     }
 
     impl_value_type!();

--- a/poem-openapi/src/types/external/any.rs
+++ b/poem-openapi/src/types/external/any.rs
@@ -1,7 +1,7 @@
 use serde_json::Value;
 
 use crate::{
-    registry::{MetaSchema, MetaSchemaRef},
+    registry::MetaSchemaRef,
     types::{ParseFromJSON, ParseResult, ToJSON, Type, TypeName},
 };
 
@@ -12,7 +12,7 @@ impl Type for Value {
     };
 
     fn schema_ref() -> MetaSchemaRef {
-        MetaSchemaRef::Inline(MetaSchema::ANY)
+        MetaSchemaRef::Inline(Box::new(Self::NAME.into()))
     }
 
     impl_value_type!();

--- a/poem-openapi/src/types/external/bool.rs
+++ b/poem-openapi/src/types/external/bool.rs
@@ -16,7 +16,7 @@ impl Type for bool {
     };
 
     fn schema_ref() -> MetaSchemaRef {
-        MetaSchemaRef::Inline(Self::NAME.into())
+        MetaSchemaRef::Inline(Box::new(Self::NAME.into()))
     }
 
     impl_value_type!();

--- a/poem-openapi/src/types/external/datetime.rs
+++ b/poem-openapi/src/types/external/datetime.rs
@@ -17,7 +17,7 @@ impl Type for DateTime<FixedOffset> {
     };
 
     fn schema_ref() -> MetaSchemaRef {
-        MetaSchemaRef::Inline(Self::NAME.into())
+        MetaSchemaRef::Inline(Box::new(Self::NAME.into()))
     }
 
     impl_value_type!();

--- a/poem-openapi/src/types/external/floats.rs
+++ b/poem-openapi/src/types/external/floats.rs
@@ -19,7 +19,7 @@ macro_rules! impl_type_for_floats {
             };
 
             fn schema_ref() -> MetaSchemaRef {
-                MetaSchemaRef::Inline(Self::NAME.into())
+                MetaSchemaRef::Inline(Box::new(Self::NAME.into()))
             }
 
             impl_value_type!();

--- a/poem-openapi/src/types/external/integers.rs
+++ b/poem-openapi/src/types/external/integers.rs
@@ -19,7 +19,7 @@ macro_rules! impl_type_for_integers {
             };
 
             fn schema_ref() -> MetaSchemaRef {
-                MetaSchemaRef::Inline(Self::NAME.into())
+                MetaSchemaRef::Inline(Box::new(Self::NAME.into()))
             }
 
             impl_value_type!();

--- a/poem-openapi/src/types/external/string.rs
+++ b/poem-openapi/src/types/external/string.rs
@@ -16,7 +16,7 @@ impl Type for String {
     };
 
     fn schema_ref() -> MetaSchemaRef {
-        MetaSchemaRef::Inline(Self::NAME.into())
+        MetaSchemaRef::Inline(Box::new(Self::NAME.into()))
     }
 
     impl_value_type!();
@@ -64,7 +64,7 @@ impl<'a> Type for &'a str {
     };
 
     fn schema_ref() -> MetaSchemaRef {
-        MetaSchemaRef::Inline(Self::NAME.into())
+        MetaSchemaRef::Inline(Box::new(Self::NAME.into()))
     }
 
     impl_value_type!();

--- a/poem-openapi/src/types/external/vec.rs
+++ b/poem-openapi/src/types/external/vec.rs
@@ -11,10 +11,10 @@ impl<T: Type> Type for Vec<T> {
     const NAME: TypeName = TypeName::Array(&T::NAME);
 
     fn schema_ref() -> MetaSchemaRef {
-        MetaSchemaRef::Inline(MetaSchema {
+        MetaSchemaRef::Inline(Box::new(MetaSchema {
             items: Some(Box::new(T::schema_ref())),
             ..MetaSchema::new("array")
-        })
+        }))
     }
 
     impl_value_type!();

--- a/poem-openapi/src/types/multipart/upload.rs
+++ b/poem-openapi/src/types/multipart/upload.rs
@@ -76,7 +76,7 @@ impl Type for Upload {
     };
 
     fn schema_ref() -> MetaSchemaRef {
-        MetaSchemaRef::Inline(Self::NAME.into())
+        MetaSchemaRef::Inline(Box::new(Self::NAME.into()))
     }
 
     impl_value_type!();

--- a/poem-openapi/src/types/password.rs
+++ b/poem-openapi/src/types/password.rs
@@ -25,7 +25,7 @@ impl Type for Password {
     };
 
     fn schema_ref() -> MetaSchemaRef {
-        MetaSchemaRef::Inline(Self::NAME.into())
+        MetaSchemaRef::Inline(Box::new(Self::NAME.into()))
     }
 
     impl_value_type!();

--- a/poem-openapi/tests/multipart.rs
+++ b/poem-openapi/tests/multipart.rs
@@ -475,13 +475,13 @@ fn inline_field() {
     );
     assert_eq!(
         meta_inner_obj.all_of[1],
-        MetaSchemaRef::Inline(MetaSchema {
+        MetaSchemaRef::Inline(Box::new(MetaSchema {
             title: Some("Inner Obj"),
             default: Some(serde_json::json!({
                 "v": 100,
             })),
             ..MetaSchema::ANY
-        })
+        }))
     );
 
     let meta_inner_enum = schema.properties[1].1.unwrap_inline();
@@ -491,10 +491,10 @@ fn inline_field() {
     );
     assert_eq!(
         meta_inner_enum.all_of[1],
-        MetaSchemaRef::Inline(MetaSchema {
+        MetaSchemaRef::Inline(Box::new(MetaSchema {
             title: Some("Inner Enum"),
             default: Some(serde_json::json!("B")),
             ..MetaSchema::ANY
-        })
+        }))
     );
 }

--- a/poem-openapi/tests/object.rs
+++ b/poem-openapi/tests/object.rs
@@ -402,13 +402,13 @@ fn inline_field() {
     );
     assert_eq!(
         meta_inner_obj.all_of[1],
-        MetaSchemaRef::Inline(MetaSchema {
+        MetaSchemaRef::Inline(Box::new(MetaSchema {
             title: Some("Inner Obj"),
             default: Some(serde_json::json!({
                 "v": 100,
             })),
             ..MetaSchema::ANY
-        })
+        }))
     );
 
     let meta_inner_enum = meta.properties[1].1.unwrap_inline();
@@ -418,10 +418,10 @@ fn inline_field() {
     );
     assert_eq!(
         meta_inner_enum.all_of[1],
-        MetaSchemaRef::Inline(MetaSchema {
+        MetaSchemaRef::Inline(Box::new(MetaSchema {
             title: Some("Inner Enum"),
             default: Some(serde_json::json!("B")),
             ..MetaSchema::ANY
-        })
+        }))
     );
 }

--- a/poem-openapi/tests/one_of.rs
+++ b/poem-openapi/tests/one_of.rs
@@ -27,13 +27,13 @@ enum MyObj {
 fn one_of_meta() {
     assert_eq!(
         MyObj::schema_ref(),
-        MetaSchemaRef::Inline(MetaSchema {
+        MetaSchemaRef::Inline(Box::new(MetaSchema {
             properties: vec![(
                 "type",
-                MetaSchemaRef::Inline(MetaSchema {
+                MetaSchemaRef::Inline(Box::new(MetaSchema {
                     enum_items: vec!["A".into(), "B".into()],
                     ..MetaSchema::new("string")
-                })
+                }))
             )],
             discriminator: Some(MetaDiscriminatorObject {
                 property_name: "type",
@@ -41,7 +41,7 @@ fn one_of_meta() {
             }),
             one_of: vec![MetaSchemaRef::Reference("A"), MetaSchemaRef::Reference("B")],
             ..MetaSchema::new("object")
-        })
+        }))
     );
 
     let mut registry = Registry::new();
@@ -130,13 +130,13 @@ fn mapping() {
 
     assert_eq!(
         MyOneOf::schema_ref(),
-        MetaSchemaRef::Inline(MetaSchema {
+        MetaSchemaRef::Inline(Box::new(MetaSchema {
             properties: vec![(
                 "type",
-                MetaSchemaRef::Inline(MetaSchema {
+                MetaSchemaRef::Inline(Box::new(MetaSchema {
                     enum_items: vec!["a1".into(), "a2".into()],
                     ..MetaSchema::new("string")
-                })
+                }))
             )],
             discriminator: Some(MetaDiscriminatorObject {
                 property_name: "type",
@@ -150,7 +150,7 @@ fn mapping() {
                 MetaSchemaRef::Reference("Def")
             ],
             ..MetaSchema::new("object")
-        })
+        }))
     );
 
     let mut registry = Registry::new();

--- a/poem-openapi/tests/operation_param.rs
+++ b/poem-openapi/tests/operation_param.rs
@@ -87,11 +87,11 @@ async fn query_default() {
     assert_eq!(meta.paths[0].operations[0].params[0].name, "v");
     assert_eq!(
         meta.paths[0].operations[0].params[0].schema,
-        MetaSchemaRef::Inline(MetaSchema {
+        MetaSchemaRef::Inline(Box::new(MetaSchema {
             format: Some("int32"),
             default: Some(json!(999)),
             ..i32::schema_ref().unwrap_inline().clone()
-        })
+        }))
     );
 
     let api = OpenApiService::new(Api).into_endpoint();

--- a/poem-openapi/tests/request.rs
+++ b/poem-openapi/tests/request.rs
@@ -32,7 +32,7 @@ fn meta() {
                 },
                 MetaMediaType {
                     content_type: "text/plain",
-                    schema: MetaSchemaRef::Inline(MetaSchema::new("string")),
+                    schema: MetaSchemaRef::Inline(Box::new(MetaSchema::new("string"))),
                 }
             ],
             required: true

--- a/poem-openapi/tests/response.rs
+++ b/poem-openapi/tests/response.rs
@@ -57,7 +57,7 @@ fn meta() {
                     status: None,
                     content: vec![MetaMediaType {
                         content_type: "text/plain",
-                        schema: MetaSchemaRef::Inline(MetaSchema::new("string")),
+                        schema: MetaSchemaRef::Inline(Box::new(MetaSchema::new("string"))),
                     }],
                     headers: vec![]
                 }
@@ -125,16 +125,16 @@ async fn headers() {
                 name: "MY-HEADER1",
                 description: Some("header1"),
                 required: true,
-                schema: MetaSchemaRef::Inline(MetaSchema {
+                schema: MetaSchemaRef::Inline(Box::new(MetaSchema {
                     format: Some("int32"),
                     ..MetaSchema::new("integer")
-                })
+                }))
             },
             MetaHeader {
                 name: "MY-HEADER2",
                 description: None,
                 required: true,
-                schema: MetaSchemaRef::Inline(MetaSchema::new("string"))
+                schema: MetaSchemaRef::Inline(Box::new(MetaSchema::new("string")))
             }
         ]
     );

--- a/poem/src/listener/mod.rs
+++ b/poem/src/listener/mod.rs
@@ -190,6 +190,7 @@ mod tests {
     use super::{AcceptorExt, *};
     use crate::listener::TcpListener;
 
+    #[cfg(feature = "tls")]
     #[tokio::test]
     #[should_panic]
     #[allow(unused_variables, unused_assignments)]

--- a/poem/src/middleware/cors.rs
+++ b/poem/src/middleware/cors.rs
@@ -249,13 +249,7 @@ impl<E: Endpoint> Endpoint for CorsEndpoint<E> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        endpoint::make_sync,
-        handler,
-        middleware::CookieJarManager,
-        web::cookie::{Cookie, CookieJar},
-        EndpointExt,
-    };
+    use crate::{endpoint::make_sync, EndpointExt};
 
     const ALLOW_ORIGIN: &str = "example.com";
     const EXPOSE_HEADER: &str = "X-My-Custom-Header";
@@ -417,8 +411,14 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
     }
 
+    #[cfg(feature = "cookie")]
     #[tokio::test]
     async fn retain_cookies() {
+        use crate::{
+            handler,
+            middleware::CookieJarManager,
+            web::cookie::{Cookie, CookieJar},
+        };
         #[handler(internal)]
         async fn index(cookie_jar: &CookieJar) {
             cookie_jar.add(Cookie::new_with_str("foo", "bar"));


### PR DESCRIPTION
## 1. fix cargo test --package poem

```
[w@ww poem]$ cargo test --package poem
   Compiling poem v1.0.1 (/home/w/repos/fork_repos/poem/poem)
error[E0432]: unresolved imports `crate::middleware::CookieJarManager`, `crate::web::cookie`
   --> poem/src/middleware/cors.rs:255:9
    |
255 |         middleware::CookieJarManager,
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `CookieJarManager` in `middleware`
256 |         web::cookie::{Cookie, CookieJar},
    |              ^^^^^^ could not find `cookie` in `web`

error[E0433]: failed to resolve: use of undeclared type `TlsConfig`
   --> poem/src/listener/mod.rs:204:18
    |
204 |             .tls(TlsConfig::new())
    |                  ^^^^^^^^^ use of undeclared type `TlsConfig`

error[E0599]: no method named `tls` found for struct `listener::tcp::TcpListener` in the current scope
   --> poem/src/listener/mod.rs:204:14
    |
204 |             .tls(TlsConfig::new())
    |              ^^^ method not found in `listener::tcp::TcpListener<&str>`
    |
   ::: poem/src/listener/tcp.rs:14:1
    |
14  | pub struct TcpListener<T> {
    | ------------------------- method `tls` not found for this
```

## 2. fix clippy::large_enum_variant

```
warning: large size difference between variants
   --> poem-openapi/src/registry/mod.rs:250:5
    |
250 |     Inline(MetaSchema),
    |     ^^^^^^^^^^^^^^^^^^ this variant is 456 bytes
    |
    = note: `#[warn(clippy::large_enum_variant)]` on by default
note: and the second-largest variant is 16 bytes:
   --> poem-openapi/src/registry/mod.rs:251:5
    |
251 |     Reference(&'static str),
    |     ^^^^^^^^^^^^^^^^^^^^^^^
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant
help: consider boxing the large fields to reduce the total size of the enum
    |
250 |     Inline(Box<MetaSchema>),
```

## 3. update poem-openapi CHANGLOG.md
