### PR TITLE
fix: poem-openapi: Json parsing not working for unsigned integers

### DIFF
--- a/poem-openapi/src/types/external/integers.rs
+++ b/poem-openapi/src/types/external/integers.rs
@@ -76,11 +76,81 @@ macro_rules! impl_type_for_integers {
     };
 }
 
+macro_rules! impl_type_for_unsigneds {
+    ($(($ty:ty, $format:literal)),*) => {
+        $(
+        impl Type for $ty {
+            const NAME: TypeName = TypeName::Normal {
+                ty: "integer",
+                format: Some($format),
+            };
+
+            fn schema_ref() -> MetaSchemaRef {
+                MetaSchemaRef::Inline(Box::new(Self::NAME.into()))
+            }
+
+            impl_value_type!();
+        }
+
+        impl ParseFromJSON for $ty {
+             fn parse_from_json(value: Value) -> ParseResult<Self> {
+                if let Value::Number(n) = value {
+                    let n = n
+                        .as_u64()
+                        .ok_or_else(|| ParseError::from("invalid integer"))?;
+
+                    if n < Self::MIN as u64 || n > Self::MAX as u64 {
+                        return Err(ParseError::from(format!(
+                            "Only integers from {} to {} are accepted.",
+                            Self::MIN,
+                            Self::MAX
+                        )));
+                    }
+
+                    Ok(n as Self)
+                } else {
+                    Err(ParseError::expected_type(value))
+                }
+            }
+        }
+
+        impl ParseFromParameter for $ty {
+            fn parse_from_parameter(value: Option<&str>) -> ParseResult<Self> {
+                match value {
+                    Some(value) => value.parse().map_err(ParseError::custom),
+                    None => Err(ParseError::expected_input()),
+                }
+            }
+        }
+
+        #[poem::async_trait]
+        impl ParseFromMultipartField for $ty {
+            async fn parse_from_multipart(field: Option<Field>) -> ParseResult<Self> {
+                match field {
+                    Some(field) => Ok(field.text().await?.parse()?),
+                    None => Err(ParseError::expected_input()),
+                }
+            }
+        }
+
+        impl ToJSON for $ty {
+            fn to_json(&self) -> Value {
+                Value::Number((*self).into())
+            }
+        }
+
+        )*
+    };
+}
+
 impl_type_for_integers!(
     (i8, "int8"),
     (i16, "int16"),
     (i32, "int32"),
-    (i64, "int64"),
+    (i64, "int64")
+);
+
+impl_type_for_unsigneds!(
     (u8, "uint8"),
     (u16, "uint16"),
     (u32, "uint32"),

--- a/poem-openapi/tests/validation.rs
+++ b/poem-openapi/tests/validation.rs
@@ -12,6 +12,16 @@ use poem_openapi::{
 use serde_json::json;
 
 #[test]
+fn test_u64() {
+    #[derive(Object, Debug, Eq, PartialEq)]
+    struct A {
+        n: u64,
+    }
+
+    assert_eq!(A::parse_from_json(json!({ "n": 1 })).unwrap(), A { n: 1 });
+}
+
+#[test]
 fn test_multiple_of() {
     #[derive(Object, Debug, Eq, PartialEq)]
     struct A {
@@ -346,5 +356,39 @@ fn test_multiple_validators() {
             .unwrap_err()
             .into_message(),
         "failed to parse \"A\": field `n` verification failed. maximum(500, exclusive: false)"
+    );
+}
+
+#[test]
+fn test_unsigned_integers() {
+    #[derive(Object, Debug, Eq, PartialEq)]
+    struct A {
+        u8: u8,
+        u16: u16,
+        u32: u32,
+        u64: u64,
+    }
+    assert_eq!(
+        A::parse_from_json(json!({
+            "u8": u8::MAX as u64,
+            "u16": u16::MAX as u64,
+            "u32": u32::MAX as u64,
+            "u64": u64::MAX as u64,
+        })).unwrap(), A {
+            u8: u8::MAX,
+            u16: u16::MAX,
+            u32: u32::MAX,
+            u64: u64::MAX,
+        });
+    assert_eq!(
+        A::parse_from_json(json!({
+            "u8": u8::MAX as u64 + 1,
+            "u16": u16::MAX as u64,
+            "u32": u32::MAX as u64,
+            "u64": u64::MAX as u64,
+        }))
+            .unwrap_err()
+            .into_message(),
+        "failed to parse \"integer($uint8)\": Only integers from 0 to 255 are accepted. (occurred while parsing \"A\")"
     );
 }


### PR DESCRIPTION
There are some issues in the Json numeric validation macro due to integer arithmetic making not possible to define any structures with unsigned integers.

A simple test case like the following:
```rust
#[test]
fn test_u64() {
#[derive(Object, Debug, Eq, PartialEq)]
    struct A {
        n: u64,
    }
    assert_eq!(A::parse_from_json(json!({ "n": 1 })).unwrap(), A { n: 1 });
}
```


Was causing parser to fail because of the conversion of _Self.MIN_ and _Self.MAX_ as **i64** when _Self_ is unsigned, which are evaluated as 0 and -1 respectively. In this case, the error output prints out _Self.MAX_ instead of _Self.MAX as i64_, so it's not really straightforward to determine what's wrong with the limits.

```
 ---- test_u64 stdout ----
 thread 'test_u64' panicked at 'called `Result::unwrap()` on an `Err`
value: ParseError { message: "failed to parse \"integer($uint64)\":
Only integers from 0 to 18446744073709551615 are accepted.
(occurred while parsing \"A\")", phantom: PhantomData }', poem-openapi/tests/validation.rs:21:54
```

As I'm not a rust expert, I'm proposing a quick fix duplicating the macro to cover signed and unsigned integers logic separately with a couple of additional tests to cover the case. 
