### PR TITLE
Add basic cache for ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
           toolchain: 1.56.1
           override: true
           components: rustfmt, clippy
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v1
       - name: Install cargo-hack
         run: cargo install cargo-hack
       - name: Check with clippy

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -22,6 +22,8 @@ jobs:
           toolchain: 1.56.1
           override: true
           components: rustfmt
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v1
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1
         with:


### PR DESCRIPTION
Setup Swatinem/rust-cache@v1

If the cache is hit, it can reduce the ci time by roughly 8 minutes.

Signed-off-by: Chojan Shang <psiace@outlook.com>