### PR TITLE
Fix playground in book

### DIFF
--- a/docs/book.toml
+++ b/docs/book.toml
@@ -4,3 +4,6 @@ description = "Poem Book"
 src = "src"
 language = "en"
 title = "Poem Book"
+
+[rust]
+edition = "2021"


### PR DESCRIPTION
I was just poking around the [book](https://poem.rs/openapi/custom_request.html) and found that pushing the play button results in a compilation error as the default edition is 2015 (which doesn't have `async`). I _think_ this will fix it based on the [mdBook book](https://rust-lang.github.io/mdBook/format/configuration/general.html).