### PR TITLE
Include route to openapi.json in Quickstart.

### DIFF
--- a/docs/en/src/openapi/quickstart.md
+++ b/docs/en/src/openapi/quickstart.md
@@ -42,7 +42,12 @@ async fn main() -> Result<(), std::io::Error> {
     // Start the server and specify that the root path of the API is /api, and the path of Swagger UI is /
     poem::Server::new(listener)
         .await?
-        .run(Route::new().nest("/api", api_service).nest("/", ui))
+        .run(
+            Route::new()
+            .nest("/openapi.json", api_service.spec_endpoint())
+            .nest("/api", api_service)
+            .nest("/", ui)
+        )
         .await
 }
 ```

--- a/docs/en/src/openapi/quickstart.md
+++ b/docs/en/src/openapi/quickstart.md
@@ -38,13 +38,16 @@ async fn main() -> Result<(), std::io::Error> {
   
     // Enable the Swagger UI
     let ui = api_service.swagger_ui();
+    
+    // Enable the OpenAPI specification
+    let spec = api_service.spec_endpoint();
 
     // Start the server and specify that the root path of the API is /api, and the path of Swagger UI is /
     poem::Server::new(listener)
         .await?
         .run(
             Route::new()
-            .nest("/openapi.json", api_service.spec_endpoint())
+            .at("/openapi.json", spec)
             .nest("/api", api_service)
             .nest("/", ui)
         )

--- a/docs/zh-CN/src/openapi/quickstart.md
+++ b/docs/zh-CN/src/openapi/quickstart.md
@@ -40,7 +40,12 @@ async fn main() -> Result<(), std::io::Error> {
     // 启动服务器，并指定api的根路径为 /api，Swagger UI的路径为 /
     poem::Server::new(listener)
         .await?
-        .run(Route::new().nest("/api", api_service).nest("/", ui))
+        .run(
+            Route::new()
+            .nest("/openapi.json", api_service.spec_endpoint())
+            .nest("/api", api_service)
+            .nest("/", ui)
+        )
         .await
 }
 ```

--- a/docs/zh-CN/src/openapi/quickstart.md
+++ b/docs/zh-CN/src/openapi/quickstart.md
@@ -37,12 +37,16 @@ async fn main() -> Result<(), std::io::Error> {
     // 开启Swagger UI
     let ui = api_service.swagger_ui();
 
+    // TODO: translate the below
+    // Enable the OpenAPI specification
+    let spec = api_service.spec_endpoint();
+
     // 启动服务器，并指定api的根路径为 /api，Swagger UI的路径为 /
     poem::Server::new(listener)
         .await?
         .run(
             Route::new()
-            .nest("/openapi.json", api_service.spec_endpoint())
+            .at("/openapi.json", spec)
             .nest("/api", api_service)
             .nest("/", ui)
         )


### PR DESCRIPTION
Personally, the document itself is a very important piece of using OpenAPI. Including it in the Quickstart will hopefully make adoption that tiny bit smoother for new users.

It may be better to put it on its own line like the SwaggerUI with a comment, but I don't know Chinese and figure it's better to keep both up to date 😅 