### PR TITLE
Omit empty security schemas from OpenAPI document.

### DIFF
--- a/poem-openapi-derive/src/api.rs
+++ b/poem-openapi-derive/src/api.rs
@@ -310,7 +310,7 @@ fn generate_operation(
     let mut has_request_payload = false;
     let mut request_meta = quote!(::std::option::Option::None);
     let mut params_meta = Vec::new();
-    let mut security_requirement = quote!(::std::option::Option::None);
+    let mut security = quote!(::std::vec![]);
 
     for i in 1..item_method.sig.inputs.len() {
         let arg = &mut item_method.sig.inputs[i];
@@ -358,7 +358,9 @@ fn generate_operation(
                 use_args.push(pname);
 
                 let scopes = &auth.scopes;
-                security_requirement = quote!(::std::option::Option::Some((<#arg_ty as #crate_name::SecurityScheme>::NAME, ::std::vec![#(#crate_name::OAuthScopes::name(&#scopes)),*])));
+                security = quote!(::std::vec![::std::collections::HashMap::from([
+                    (<#arg_ty as #crate_name::SecurityScheme>::NAME, ::std::vec![#(#crate_name::OAuthScopes::name(&#scopes)),*])
+                ])]);
                 ctx.security_schemes.push(quote!(#arg_ty));
             }
 
@@ -588,7 +590,7 @@ fn generate_operation(
             request: #request_meta,
             responses: <#res_ty as #crate_name::ApiResponse>::meta(),
             deprecated: #deprecated,
-            security: ::std::vec![::std::iter::FromIterator::from_iter(::std::iter::IntoIterator::into_iter(#security_requirement))],
+            security: #security,
         }
     });
 

--- a/poem-openapi/src/registry/ser.rs
+++ b/poem-openapi/src/registry/ser.rs
@@ -77,6 +77,7 @@ impl<'a> Serialize for Document<'a> {
         struct Components<'a> {
             schemas: &'a HashMap<&'static str, MetaSchema>,
             #[serde(rename = "securitySchemes")]
+            #[serde(skip_serializing_if = "BTreeMap::is_empty")]
             security_schemes: &'a BTreeMap<&'static str, MetaSecurityScheme>,
         }
 

--- a/poem-openapi/tests/security_scheme.rs
+++ b/poem-openapi/tests/security_scheme.rs
@@ -51,6 +51,26 @@ fn desc() {
 }
 
 #[tokio::test]
+async fn no_auth() {
+    struct MyApi;
+
+    #[OpenApi]
+    impl MyApi {
+        #[oai(path = "/test", method = "get")]
+        async fn test(&self) -> PlainText<String> {
+            PlainText("test".to_string())
+        }
+    }
+
+    let service = OpenApiService::new(MyApi, "test", "1.0");
+    let spec_string = service.spec();
+    let spec = serde_json::from_str::<serde_json::Value>(&spec_string).unwrap();
+
+    assert_eq!(spec["paths"]["/test"]["get"].get("security"), None);
+    assert_eq!(spec["components"].get("securitySchemes"), None);
+}
+
+#[tokio::test]
 async fn basic_auth() {
     #[derive(SecurityScheme)]
     #[oai(type = "basic")]


### PR DESCRIPTION
This is mostly because my generator currently interprets the presence of security as a reason to require security (even if it's empty). Really I oughta fix my generator but it looked like security (on the path at least) was intended to be omitted due to [this line](https://github.com/poem-web/poem/blob/04654b8ffd42a7240a08a8059b31c7a3d1d2ef99/poem-openapi/src/registry/mod.rs#L423), so I figured the change would be welcome.

By the way I very rarely touch macros so if there's a more clever way to do this let me know. Thanks!!