### PR TITLE
docs: Add some basic documentation to the OpenApi derive macro.

### DIFF
--- a/poem-openapi-derive/Cargo.toml
+++ b/poem-openapi-derive/Cargo.toml
@@ -29,3 +29,6 @@ indexmap = "1.7.0"
 regex = "1.5.4"
 http = "0.2.5"
 mime = "0.3.16"
+
+[dev-dependencies]
+poem-openapi = { path = "../poem-openapi" }

--- a/poem-openapi-derive/src/lib.rs
+++ b/poem-openapi-derive/src/lib.rs
@@ -71,6 +71,34 @@ pub fn derive_request(input: TokenStream) -> TokenStream {
     }
 }
 
+/// Deriving OpenApi on a struct is the primary way in which you create an
+/// OpenAPI server.
+///
+/// # Example
+///
+/// ```
+/// use poem_openapi::{payload::PlainText, OpenApi};
+///
+/// struct Api;
+///
+/// #[OpenApi]
+/// impl Api {
+///     /// Hello world
+///     #[oai(path = "/hello", method = "get")]
+///     async fn index(&self) -> PlainText<&'static str> {
+///         PlainText("Hello World")
+///     }
+/// }
+/// ```
+///
+/// # Arguments
+///
+/// You can modify the the derived API in several ways by passing in arguments
+/// to the derive macro.
+///
+/// 1. Using `#[OpenApi(prefix_path="/v1")]` would put
+/// `/v1` before every other route. In the example above, making a GET request
+/// to `/v1/hello` would return "Hello World".
 #[proc_macro_attribute]
 #[allow(non_snake_case)]
 pub fn OpenApi(args: TokenStream, input: TokenStream) -> TokenStream {


### PR DESCRIPTION
I had a bit of trouble figuring out how to add a prefix to all paths which would reflect properly in the spec/docs UI so I figured I'd add a note to the macro in docs.rs. If there's a better place to stick this info just let me know, happy to move it around.