### PR TITLE
docs: Add examples to some OpenApi and Operation attributes.

### DIFF
--- a/poem-openapi/src/docs/openapi.md
+++ b/poem-openapi/src/docs/openapi.md
@@ -2,21 +2,81 @@ Define a OpenAPI.
 
 # Macro parameters
 
-| Attribute   | description                               | Type   | Optional |
-|-------------|-------------------------------------------|--------|----------|
-| prefix_path | Define the prefix for all operation paths | string | Y        |
-| tag         | Define a tag for all operations.          | string | Y        |
+These are attributes that can be added to the `#[OpenApi]` attribute.
+
+| Attribute   | description                                                                                                      | Type   | Optional |
+|-------------|------------------------------------------------------------------------------------------------------------------|--------|----------|
+| prefix_path | Define the prefix for all operation paths. May contain shared path parameters.                                   | string | Y        |
+| tag         | Define a tag for all operations. This must be the name of an in-scope variant of an enum which implements `Tags` | Tags   | Y        |
+
+## Example
+
+```rust
+use poem_openapi::{OpenApi, Tags};
+use poem_openapi::param::Path;
+use poem_openapi::payload::PlainText;
+
+#[derive(Tags)]
+enum MyTags {
+    V1
+}
+
+struct Api;
+
+#[OpenApi(prefix_path = "/v1/:customer_id", tag = "MyTags::V1")]
+impl Api {
+    /// Greet the customer
+    ///
+    /// # Example
+    /// 
+    /// Call `/v1/1234/hello` to get the response `"Hello 1234!"`. 
+    #[oai(path = "/hello", method = "get")]
+    async fn hello(&self, customer_id: Path<String>) -> PlainText<String> {
+        PlainText(format!("Hello {}!", customer_id.0))
+    }
+}
+```
 
 # Operation parameters
 
+Parameters that can be passed into the `#[oai()]` attribute above each operation function within an `OpenApi`.
+
 | Attribute    | description                                                                                                          | Type   | Optional |
 |--------------|----------------------------------------------------------------------------------------------------------------------|--------|----------|
-| path         | HTTP uri.                                                                                                            | string | N        |
+| path         | URI path optionally containing path parameters (e.g., "/:name/hello")                                                | string | N        |
 | method       | HTTP method. The possible values are "get", "post", "put", "delete", "head", "options", "connect", "patch", "trace". | string | N        |
 | deprecated   | Operation deprecated                                                                                                 | bool   | Y        |
-| tag          | Operation tag                                                                                                        | Tags   | Y        |
+| tag          | Tag to use for an operation. Must be a variant of an enum which implements `Tags`                                    | Tags   | Y        |
 | operation_id | Unique string used to identify the operation.                                                                        | string | Y        |
 | transform    | Use a function to transform the API endpoint.                                                                        | string | Y        |
+
+## Example
+
+```rust
+use poem_openapi::{OpenApi, Tags};
+use poem_openapi::param::Path;
+use poem_openapi::payload::PlainText;
+
+#[derive(Tags)]
+enum MyTags {
+    V1
+}
+
+struct Api;
+
+#[OpenApi]
+impl Api {
+    /// Greet the customer
+    ///
+    /// # Example
+    /// 
+    /// Call `/v1/1234/hello` to get the response `"Hello 1234!"`. 
+    #[oai(path = "/v1/:customer_id/hello", method = "get", tag = "MyTags::V1")]
+    async fn hello(&self, customer_id: Path<String>) -> PlainText<String> {
+        PlainText(format!("Hello {}!", customer_id.0))
+    }
+}
+```
 
 # Operation argument parameters
 


### PR DESCRIPTION
The specific goal was to add an example of the path param syntax which I had a bit of trouble discovering. ~~I feel like these examples should be tested somehow to stay in sync but not sure the best way to do that.~~

By the way, what happened to the mdbook that used to be around? I found that really helpful 😅 and there's a way in mdbook to pull in examples from docstrings, so the examples are tested, docstrings are present when checking out the docs.rs entry (e.g., where I was originally looking for `#[OpenApi]` docs before my last PR), and everything is in sync.