### PR TITLE
Add Url support to OpenAPI

### DIFF
--- a/poem-openapi/Cargo.toml
+++ b/poem-openapi/Cargo.toml
@@ -46,6 +46,7 @@ hostname-validator = { version = "1.1.0", optional = true }
 # Feature optional dependencies
 chrono = { version = "0.4.19", optional = true }
 uuid = { version = "0.8.2", optional = true }
+url = { version = "2.2.2", optional = true }
 once_cell = "1.9.0"
 
 [dev-dependencies]

--- a/poem-openapi/src/types/external/mod.rs
+++ b/poem-openapi/src/types/external/mod.rs
@@ -11,6 +11,8 @@ mod regex;
 mod slice;
 mod string;
 mod uri;
+#[cfg(feature = "url")]
+mod url;
 #[cfg(feature = "uuid")]
 mod uuid;
 mod vec;

--- a/poem-openapi/src/types/external/url.rs
+++ b/poem-openapi/src/types/external/url.rs
@@ -1,0 +1,77 @@
+use std::borrow::Cow;
+
+use poem::{http::HeaderValue, web::Field};
+use serde_json::Value;
+use url::Url;
+
+use crate::{
+    registry::{MetaSchema, MetaSchemaRef},
+    types::{
+        ParseError, ParseFromJSON, ParseFromMultipartField, ParseFromParameter, ParseResult,
+        ToHeader, ToJSON, Type,
+    },
+};
+
+impl Type for Url {
+    const IS_REQUIRED: bool = true;
+
+    type RawValueType = Self;
+
+    type RawElementValueType = Self;
+
+    fn name() -> Cow<'static, str> {
+        "string(url)".into()
+    }
+
+    fn schema_ref() -> MetaSchemaRef {
+        MetaSchemaRef::Inline(Box::new(MetaSchema::new_with_format("string", "url")))
+    }
+
+    fn as_raw_value(&self) -> Option<&Self::RawValueType> {
+        Some(self)
+    }
+
+    fn raw_element_iter<'a>(
+        &'a self,
+    ) -> Box<dyn Iterator<Item = &'a Self::RawElementValueType> + 'a> {
+        Box::new(self.as_raw_value().into_iter())
+    }
+}
+
+impl ParseFromJSON for Url {
+    fn parse_from_json(value: Value) -> ParseResult<Self> {
+        if let Value::String(value) = value {
+            Ok(value.parse()?)
+        } else {
+            Err(ParseError::expected_type(value))
+        }
+    }
+}
+
+impl ParseFromParameter for Url {
+    fn parse_from_parameter(value: &str) -> ParseResult<Self> {
+        value.parse().map_err(ParseError::custom)
+    }
+}
+
+#[poem::async_trait]
+impl ParseFromMultipartField for Url {
+    async fn parse_from_multipart(field: Option<Field>) -> ParseResult<Self> {
+        match field {
+            Some(field) => Ok(field.text().await?.parse()?),
+            None => Err(ParseError::expected_input()),
+        }
+    }
+}
+
+impl ToJSON for Url {
+    fn to_json(&self) -> Value {
+        Value::String(self.to_string())
+    }
+}
+
+impl ToHeader for Url {
+    fn to_header(&self) -> Option<HeaderValue> {
+        HeaderValue::from_str(&self.to_string()).ok()
+    }
+}


### PR DESCRIPTION
While `Uri` support exists, the popular crate `Url` is not supported. This implements support for that derived from the `Uri` implementation.