### PR TITLE
Integrate poem-openapi with `bson::oid::ObjectId`

### DIFF
--- a/poem-openapi/Cargo.toml
+++ b/poem-openapi/Cargo.toml
@@ -47,6 +47,7 @@ hostname-validator = { version = "1.1.0", optional = true }
 chrono = { version = "0.4.19", optional = true }
 uuid = { version = "0.8.2", optional = true }
 url = { version = "2.2.2", optional = true }
+bson = { version = "2.0.0", optional = true }
 once_cell = "1.9.0"
 
 [dev-dependencies]

--- a/poem-openapi/README.md
+++ b/poem-openapi/README.md
@@ -60,6 +60,7 @@ To avoid compiling unused dependencies, Poem gates certain features, some of whi
 | hostname   | Support for hostname string                                           |
 | uuid       | Integrate with the [`uuid` crate](https://crates.io/crates/uuid)      |
 | url        | Integrate with the [`url` crate](https://crates.io/crates/url)        |
+| bson        | Integrate with the [`bson` crate](https://crates.io/crates/bson)        |
 
 ## Safety
 

--- a/poem-openapi/src/lib.rs
+++ b/poem-openapi/src/lib.rs
@@ -101,6 +101,7 @@
 //! | hostname   | Support for hostname string |
 //! | uuid       | Integrate with the [`uuid` crate](https://crates.io/crates/uuid)|
 //! | url        | Integrate with the [`url` crate](https://crates.io/crates/url) |
+//! | bson        | Integrate with the [`bson` crate](https://crates.io/crates/bson) |
 
 #![doc(html_favicon_url = "https://raw.githubusercontent.com/poem-web/poem/master/favicon.ico")]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/poem-web/poem/master/logo.png")]

--- a/poem-openapi/src/types/external/bson.rs
+++ b/poem-openapi/src/types/external/bson.rs
@@ -1,0 +1,74 @@
+use std::{borrow::Cow};
+
+use poem::{http::HeaderValue, web::Field};
+use serde_json::Value;
+use bson::oid::ObjectId;
+
+use crate::{
+    registry::{MetaSchema, MetaSchemaRef},
+    types::{
+        ParseError, ParseFromJSON, ParseFromMultipartField, ParseFromParameter, ParseResult,
+        ToHeader, ToJSON, Type,
+    },
+};
+
+impl Type for ObjectId {
+    const IS_REQUIRED: bool = true;
+
+    type RawValueType = Self;
+
+    type RawElementValueType = Self;
+
+    fn name() -> Cow<'static, str> {
+        "object(ObjectID)".into()
+    }
+
+    fn schema_ref() -> MetaSchemaRef {
+        MetaSchemaRef::Inline(Box::new(MetaSchema::new_with_format("object", "oid")))
+    }
+
+    fn as_raw_value(&self) -> Option<&Self::RawValueType> {
+        Some(self)
+    }
+
+    fn raw_element_iter<'a>(
+        &'a self,
+    ) -> Box<dyn Iterator<Item = &'a Self::RawElementValueType> + 'a> {
+        todo!()
+    }
+}
+
+impl ParseFromJSON for ObjectId {
+    fn parse_from_json(value: Value) -> ParseResult<Self> {
+        let v: ObjectId = serde_json::from_value(value)?;
+        Ok(v)
+    }
+}
+
+impl ParseFromParameter for ObjectId {
+    fn parse_from_parameter(value: &str) -> ParseResult<Self> {
+        ParseResult::Ok(ObjectId::parse_str(value)?)
+    }
+}
+
+#[poem::async_trait]
+impl ParseFromMultipartField for ObjectId {
+    async fn parse_from_multipart(field: Option<Field>) -> ParseResult<Self> {
+        match field {
+            Some(field) => Ok(ObjectId::parse_str(field.text().await?)?),
+            None => Err(ParseError::expected_input()),
+        }
+    }
+}
+
+impl ToJSON for ObjectId {
+    fn to_json(&self) -> Value {
+        serde_json::to_value(self).unwrap()
+    }
+}
+
+impl ToHeader for ObjectId {
+    fn to_header(&self) -> Option<HeaderValue> {
+        HeaderValue::from_str(&self.to_hex()).ok()
+    }
+}

--- a/poem-openapi/src/types/external/mod.rs
+++ b/poem-openapi/src/types/external/mod.rs
@@ -18,3 +18,5 @@ mod url;
 #[cfg(feature = "uuid")]
 mod uuid;
 mod vec;
+#[cfg(feature = "bson")]
+mod bson;


### PR DESCRIPTION
This adds a `Type` impl for `bson`'s `ObjectId` type. 
Some feedback would be greatly appreciated - I'm not sure what `fn raw_element_iter` is supposed to do, or that the name I've given the schema is good.