### PR TITLE
fix: unsupported media-type (415) instead of method not allowed (405)

### DIFF
--- a/poem-openapi/src/error.rs
+++ b/poem-openapi/src/error.rs
@@ -65,7 +65,7 @@ pub enum ContentTypeError {
 
 impl ResponseError for ContentTypeError {
     fn status(&self) -> StatusCode {
-        StatusCode::METHOD_NOT_ALLOWED
+        StatusCode::UNSUPPORTED_MEDIA_TYPE
     }
 }
 

--- a/poem-openapi/tests/api.rs
+++ b/poem-openapi/tests/api.rs
@@ -250,7 +250,7 @@ async fn payload_request() {
                 .body("100"),
         )
         .await;
-    assert_eq!(resp.status(), StatusCode::METHOD_NOT_ALLOWED);
+    assert_eq!(resp.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
 }
 
 #[tokio::test]

--- a/poem/src/error.rs
+++ b/poem/src/error.rs
@@ -585,8 +585,8 @@ pub enum ParseFormError {
 impl ResponseError for ParseFormError {
     fn status(&self) -> StatusCode {
         match self {
-            ParseFormError::InvalidContentType(_) => StatusCode::BAD_REQUEST,
-            ParseFormError::ContentTypeRequired => StatusCode::BAD_REQUEST,
+            ParseFormError::InvalidContentType(_) => StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            ParseFormError::ContentTypeRequired => StatusCode::UNSUPPORTED_MEDIA_TYPE,
             ParseFormError::UrlDecode(_) => StatusCode::BAD_REQUEST,
         }
     }
@@ -644,8 +644,8 @@ pub enum ParseMultipartError {
 impl ResponseError for ParseMultipartError {
     fn status(&self) -> StatusCode {
         match self {
-            ParseMultipartError::InvalidContentType(_) => StatusCode::BAD_REQUEST,
-            ParseMultipartError::ContentTypeRequired => StatusCode::BAD_REQUEST,
+            ParseMultipartError::InvalidContentType(_) => StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            ParseMultipartError::ContentTypeRequired => StatusCode::UNSUPPORTED_MEDIA_TYPE,
             ParseMultipartError::Multipart(_) => StatusCode::BAD_REQUEST,
             ParseMultipartError::Utf8(_) => StatusCode::BAD_REQUEST,
             ParseMultipartError::Io(_) => StatusCode::BAD_REQUEST,


### PR DESCRIPTION
Now, if the `ContentType` is incorrect, the server returns a `405` error, but according to the specification, `415` is more appropriate. 

https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/415
https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.13

In addition, such a response code is used in most web frameworks 🤔 