### PR TITLE
Implement OpenApi trait for monuples

### DIFF
--- a/poem-openapi/src/base.rs
+++ b/poem-openapi/src/base.rs
@@ -402,6 +402,8 @@ impl_openapi_for_tuple!((T1, 0), (T2, 1), (T3, 2), (T4, 3));
 impl_openapi_for_tuple!((T1, 0), (T2, 1), (T3, 2));
 #[rustfmt::skip]
 impl_openapi_for_tuple!((T1, 0), (T2, 1));
+#[rustfmt::skip]
+impl_openapi_for_tuple!((T1, 0));
 
 impl OpenApi for () {
     fn meta() -> Vec<MetaApi> {


### PR DESCRIPTION
Right now, the `OpenApi` trait is implemented on tuples of all lengths from 0 through 16 _except_ 1.

It may seem useless to use a `(T,)` when you could just use `T` directly, but there are some cases where it's useful. For example, I have a macro which generates a function which makes a tuple implementing `OpenApi` from a list of types, but it doesn't work when there's only one type listed.