### PR TITLE
Fix error.ts typo

### DIFF
--- a/poem/src/error.rs
+++ b/poem/src/error.rs
@@ -287,8 +287,7 @@ impl From<StatusCode> for Error {
 }
 
 impl Error {
-    /// Create a new error object from any error type with `503
-    /// INTERNAL_SERVER_ERROR` status code.
+    /// Create a new error object from any error type with a status code.
     #[inline]
     pub fn new<T: StdError + Send + Sync + 'static>(err: T, status: StatusCode) -> Self {
         Self {
@@ -312,8 +311,7 @@ impl Error {
         StatusError(status).into()
     }
 
-    /// Create a new error object from string with `503 INTERNAL_SERVER_ERROR`
-    /// status code.
+    /// Create a new error object from a string with a status code.
     pub fn from_string(msg: impl Into<String>, status: StatusCode) -> Self {
         #[derive(Debug, thiserror::Error)]
         #[error("{0}")]


### PR DESCRIPTION
Fixes what I believe are typos in `poem/src/error.ts` These two functions seem to mention the `503` error code specifically but I believe it is incorrect, and it creates errors with the provided status codes.