### PR TITLE
When use Json as an extractor, the `Content-Type` should be `application/[prefix+]json`

### DIFF
--- a/poem/Cargo.toml
+++ b/poem/Cargo.toml
@@ -20,11 +20,11 @@ categories = [
 [features]
 default = []
 websocket = ["tokio-tungstenite", "base64"]
-multipart = ["multer", "mime"]
+multipart = ["multer"]
 rustls = ["tokio-rustls", "rustls-pemfile"]
 native-tls = ["tokio-native-tls"]
 sse = []
-static-files = ["httpdate", "mime", "mime_guess", "tokio/io-util", "tokio/fs"]
+static-files = ["httpdate", "mime_guess", "tokio/io-util", "tokio/fs"]
 compression = ["async-compression", "typed-headers"]
 tower-compat = ["tower"]
 cookie = ["libcookie", "chrono", "time"]
@@ -34,7 +34,7 @@ opentelemetry = ["libopentelemetry", "opentelemetry-http", "opentelemetry-semant
 prometheus = ["libopentelemetry", "opentelemetry-prometheus", "libprometheus"]
 tempfile = ["libtempfile", "tokio/fs"]
 csrf = ["cookie", "base64", "libcsrf"]
-test = ["sse", "sse-codec", "tokio-util/compat", "mime"]
+test = ["sse", "sse-codec", "tokio-util/compat"]
 i18n = ["fluent", "fluent-langneg", "fluent-syntax", "unic-langid", "intl-memoizer"]
 acme = ["hyper/client", "rustls", "ring", "hyper-rustls", "base64", "rcgen", "x509-parser"]
 
@@ -70,7 +70,7 @@ async-compression = { version = "0.3.8", optional = true, features = ["tokio", "
 tower = { version = "0.4.8", optional = true, default-features = true, features = ["util", "buffer"] }
 chrono = { version = "0.4.19", optional = true }
 time = { version = "0.3", optional = true }
-mime = { version = "0.3.16", optional = true }
+mime = { version = "0.3.16"}
 mime_guess = { version = "2.0.3", optional = true }
 typed-headers = { version = "0.2.0", optional = true }
 rand = { version = "0.8.4", optional = true }

--- a/poem/src/error.rs
+++ b/poem/src/error.rs
@@ -641,6 +641,17 @@ impl ResponseError for ParseJsonError {
     }
 }
 
+/// A missing json Content-Type error value when parsing header.
+#[derive(Debug, thiserror::Error)]
+#[error("Missing `Content-Type: application/json`")]
+pub struct MissingJsonContentTypeError;
+
+impl ResponseError for MissingJsonContentTypeError {
+    fn status(&self) -> StatusCode {
+        StatusCode::UNSUPPORTED_MEDIA_TYPE
+    }
+}
+
 /// A possible error value when parsing query.
 #[derive(Debug, thiserror::Error)]
 #[error(transparent)]

--- a/poem/src/web/json.rs
+++ b/poem/src/web/json.rs
@@ -23,7 +23,7 @@ use crate::{
 /// ```
 /// use poem::{
 ///     handler,
-///     http::{Method, StatusCode,header},
+///     http::{header, Method, StatusCode},
 ///     post,
 ///     test::TestClient,
 ///     web::Json,

--- a/poem/src/web/json.rs
+++ b/poem/src/web/json.rs
@@ -4,8 +4,10 @@ use http::StatusCode;
 use serde::{de::DeserializeOwned, Serialize};
 
 use crate::{
-    error::ParseJsonError, http::header, web::RequestBody, FromRequest, IntoResponse, Request,
-    Response, Result,
+    error::{MissingJsonContentTypeError, ParseJsonError},
+    http::header,
+    web::RequestBody,
+    FromRequest, IntoResponse, Request, Response, Result,
 };
 
 /// JSON extractor and response.
@@ -100,9 +102,28 @@ impl<T> DerefMut for Json<T> {
 
 #[async_trait::async_trait]
 impl<'a, T: DeserializeOwned> FromRequest<'a> for Json<T> {
-    async fn from_request(_req: &'a Request, body: &mut RequestBody) -> Result<Self> {
-        let data = body.take()?.into_bytes().await?;
-        Ok(Self(serde_json::from_slice(&data).map_err(ParseJsonError)?))
+    async fn from_request(req: &'a Request, body: &mut RequestBody) -> Result<Self> {
+        if is_json_content_type(req) {
+            let data = body.take()?.into_bytes().await?;
+            Ok(Self(serde_json::from_slice(&data).map_err(ParseJsonError)?))
+        } else {
+            Err(MissingJsonContentTypeError.into())
+        }
+    }
+}
+
+fn is_json_content_type(req: &Request) -> bool {
+    if let Some(value) = req.header(header::CONTENT_TYPE) {
+        if let Ok(content_type) = value.parse::<mime::Mime>() {
+            // the content-type should be `application/[prefix+]json`
+            content_type.type_() == "application"
+                && (content_type.subtype() == "json"
+                    || content_type.suffix().map_or(false, |v| v == "json"))
+        } else {
+            false
+        }
+    } else {
+        false
     }
 }
 
@@ -146,11 +167,29 @@ mod tests {
 
         let cli = TestClient::new(index);
         cli.post("/")
-            .header(header::CONTENT_TYPE, "application/json")
-            .body_json(&json!({"name": "abc", "value": 100}))
+            .body_json(&json!({"name": "abc", "value": 100})) // body_json has already set request with `application/json` content type
             .send()
             .await
             .assert_status_is_ok();
+    }
+    #[tokio::test]
+    async fn test_json_extractor_fail() {
+        #[handler(internal)]
+        async fn index(query: Json<CreateResource>) {
+            assert_eq!(query.name, "abc");
+            assert_eq!(query.value, 100);
+        }
+        let create_resource = CreateResource {
+            name: "abc".to_string(),
+            value: 100,
+        };
+        let cli = TestClient::new(index);
+        cli.post("/")
+            // .header(header::CONTENT_TYPE, "application/json")
+            .body(serde_json::to_string(&create_resource).expect("Invalid json"))
+            .send()
+            .await
+            .assert_status(StatusCode::UNSUPPORTED_MEDIA_TYPE);
     }
 
     #[tokio::test]

--- a/poem/src/web/json.rs
+++ b/poem/src/web/json.rs
@@ -45,10 +45,12 @@ use crate::{
 /// let cli = TestClient::new(app);
 ///
 /// # tokio::runtime::Runtime::new().unwrap().block_on(async {
-/// let resp = cli.post("/")
+/// let resp = cli
+///     .post("/")
 ///     .header(header::CONTENT_TYPE, "application/json")
 ///     .body(r#"{"name": "foo"}"#)
-///     .send().await;
+///     .send()
+///     .await;
 /// resp.assert_status_is_ok();
 /// resp.assert_text("welcome foo!").await;
 /// # });

--- a/poem/src/web/json.rs
+++ b/poem/src/web/json.rs
@@ -23,7 +23,7 @@ use crate::{
 /// ```
 /// use poem::{
 ///     handler,
-///     http::{Method, StatusCode},
+///     http::{Method, StatusCode,header},
 ///     post,
 ///     test::TestClient,
 ///     web::Json,
@@ -45,7 +45,10 @@ use crate::{
 /// let cli = TestClient::new(app);
 ///
 /// # tokio::runtime::Runtime::new().unwrap().block_on(async {
-/// let resp = cli.post("/").body(r#"{"name": "foo"}"#).send().await;
+/// let resp = cli.post("/")
+///     .header(header::CONTENT_TYPE, "application/json")
+///     .body(r#"{"name": "foo"}"#)
+///     .send().await;
 /// resp.assert_status_is_ok();
 /// resp.assert_text("welcome foo!").await;
 /// # });


### PR DESCRIPTION
When use Json as an extractor, the `Content-Type` should be `application/[prefix+]json`, 
if the content-type is not  `application/json`, poem return an error instead of continuing parsing body


