### PR TITLE
Make TokioMetrics endpoint public

### DIFF
--- a/poem/src/middleware/mod.rs
+++ b/poem/src/middleware/mod.rs
@@ -25,7 +25,7 @@ mod tower_compat;
 mod tracing_mw;
 
 #[cfg(feature = "tokio-metrics")]
-pub use tokio_metrics_mw::TokioMetrics;
+pub use tokio_metrics_mw::{TokioMetrics, TokioMetricsEndpoint};
 
 #[cfg(feature = "compression")]
 pub use self::compression::{Compression, CompressionEndpoint};

--- a/poem/src/middleware/tokio_metrics_mw.rs
+++ b/poem/src/middleware/tokio_metrics_mw.rs
@@ -75,6 +75,7 @@ impl<E: Endpoint> Middleware<E> for TokioMetrics {
     }
 }
 
+/// Endpoint for [`tokio-metrics`](https://crates.io/crates/tokio-metrics)
 pub struct TokioMetricsEndpoint<E> {
     inner: E,
     interval: Duration,


### PR DESCRIPTION
I'm using a function to bundle all my routes for consistency in testing etc that depends on the endpoint types being pub.
-> Also consistency with other middlewares.