### PR TITLE
Add the ability for parameters to come from urlencoded forms.

### DIFF
--- a/poem-openapi/Cargo.toml
+++ b/poem-openapi/Cargo.toml
@@ -29,6 +29,7 @@ poem = { path = "../poem", version = "1.3.16", features = ["multipart", "tempfil
 
 tokio = { version = "1.17.0", features = ["fs"] }
 serde_json = "1.0.68"
+serde_urlencoded = "0.7.1"
 base64 = "0.13.0"
 serde = { version = "1.0.130", features = ["derive"] }
 derive_more = "0.99.16"

--- a/poem-openapi/src/payload/form.rs
+++ b/poem-openapi/src/payload/form.rs
@@ -1,0 +1,79 @@
+use std::ops::{Deref, DerefMut};
+
+use poem::{FromRequest, IntoResponse, Request, RequestBody, Response, Result};
+use serde::de::DeserializeOwned;
+use poem::error::ParseFormError;
+use poem::http::{header, HeaderValue, Method};
+
+use crate::{
+    error::ParseRequestPayloadError,
+    payload::{ParsePayload, Payload},
+    registry::{MetaMediaType, MetaResponse, MetaResponses, MetaSchemaRef, Registry},
+    types::{ParseFromJSON, ToJSON, Type},
+    ApiResponse,
+};
+
+/// A url encoded form payload.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct Form<T>(pub T);
+
+impl<T> Deref for Form<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for Form<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<T: Type> Payload for Form<T> {
+    const CONTENT_TYPE: &'static str = "application/x-www-form-urlencoded";
+
+    fn schema_ref() -> MetaSchemaRef {
+        T::schema_ref()
+    }
+
+    #[allow(unused_variables)]
+    fn register(registry: &mut Registry) {
+        T::register(registry);
+    }
+}
+
+#[poem::async_trait]
+impl<T: DeserializeOwned> ParsePayload for Form<T> {
+    const IS_REQUIRED: bool = true;
+
+    async fn from_request(req: &Request, body: &mut RequestBody) -> Result<Self> {
+        if req.method() == Method::GET {
+            Ok(
+                serde_urlencoded::from_str(req.uri().query().unwrap_or_default())
+                    .map_err(ParseFormError::UrlDecode)
+                    .map(Self)?,
+            )
+        } else {
+            let content_type = req.headers().get(header::CONTENT_TYPE);
+            if content_type
+                != Some(&HeaderValue::from_static(
+                "application/x-www-form-urlencoded",
+            ))
+            {
+                return match content_type.and_then(|value| value.to_str().ok()) {
+                    Some(ty) => Err(ParseFormError::InvalidContentType(ty.to_string()).into()),
+                    None => Err(ParseFormError::ContentTypeRequired.into()),
+                };
+            }
+
+            Ok(Self(
+                serde_urlencoded::from_bytes(&body.take()?.into_vec().await?)
+                    .map_err(ParseFormError::UrlDecode)?,
+            ))
+        }
+    }
+}
+
+impl_apirequest_for_payload!(Form<T>, T: DeserializeOwned + Type);

--- a/poem-openapi/src/payload/form.rs
+++ b/poem-openapi/src/payload/form.rs
@@ -1,16 +1,14 @@
 use std::ops::{Deref, DerefMut};
 
-use poem::{FromRequest, IntoResponse, Request, RequestBody, Response, Result};
+use poem::{Request, RequestBody, Result};
 use serde::de::DeserializeOwned;
 use poem::error::ParseFormError;
 use poem::http::{header, HeaderValue, Method};
 
 use crate::{
-    error::ParseRequestPayloadError,
     payload::{ParsePayload, Payload},
-    registry::{MetaMediaType, MetaResponse, MetaResponses, MetaSchemaRef, Registry},
-    types::{ParseFromJSON, ToJSON, Type},
-    ApiResponse,
+    registry::{MetaSchemaRef, Registry},
+    types::Type,
 };
 
 /// A url encoded form payload.

--- a/poem-openapi/src/payload/form.rs
+++ b/poem-openapi/src/payload/form.rs
@@ -47,30 +47,22 @@ impl<T: DeserializeOwned> ParsePayload for Form<T> {
     const IS_REQUIRED: bool = true;
 
     async fn from_request(req: &Request, body: &mut RequestBody) -> Result<Self> {
-        if req.method() == Method::GET {
-            Ok(
-                serde_urlencoded::from_str(req.uri().query().unwrap_or_default())
-                    .map_err(ParseFormError::UrlDecode)
-                    .map(Self)?,
-            )
-        } else {
-            let content_type = req.headers().get(header::CONTENT_TYPE);
-            if content_type
-                != Some(&HeaderValue::from_static(
-                "application/x-www-form-urlencoded",
-            ))
-            {
-                return match content_type.and_then(|value| value.to_str().ok()) {
-                    Some(ty) => Err(ParseFormError::InvalidContentType(ty.to_string()).into()),
-                    None => Err(ParseFormError::ContentTypeRequired.into()),
-                };
-            }
-
-            Ok(Self(
-                serde_urlencoded::from_bytes(&body.take()?.into_vec().await?)
-                    .map_err(ParseFormError::UrlDecode)?,
-            ))
+        let content_type = req.headers().get(header::CONTENT_TYPE);
+        if content_type
+            != Some(&HeaderValue::from_static(
+            "application/x-www-form-urlencoded",
+        ))
+        {
+            return match content_type.and_then(|value| value.to_str().ok()) {
+                Some(ty) => Err(ParseFormError::InvalidContentType(ty.to_string()).into()),
+                None => Err(ParseFormError::ContentTypeRequired.into()),
+            };
         }
+
+        Ok(Self(
+            serde_urlencoded::from_bytes(&body.take()?.into_vec().await?)
+                .map_err(ParseFormError::UrlDecode)?,
+        ))
     }
 }
 

--- a/poem-openapi/src/payload/mod.rs
+++ b/poem-openapi/src/payload/mod.rs
@@ -8,12 +8,13 @@ mod html;
 mod json;
 mod plain_text;
 mod response;
+mod form;
 
 use poem::{Request, RequestBody, Result};
 
 pub use self::{
     attachment::Attachment, base64_payload::Base64, binary::Binary, event_stream::EventStream,
-    html::Html, json::Json, plain_text::PlainText, response::Response,
+    html::Html, json::Json, plain_text::PlainText, response::Response, form::Form,
 };
 use crate::registry::{MetaSchemaRef, Registry};
 


### PR DESCRIPTION
It only works for a urlencoded body. This works the same as poem's `Form<T>`

This introduces an extra dependency on serde_urlencoded as well, since poem does not reexport it.

I am not 100% sure that this should be in the `payload` module, since you can't really give a form response. 

This is related to #241, even though it does not solve that issue it is enough for me to no longer require that one solved.