### PR TITLE
Advance version of indexmap for openapi-derive

### DIFF
--- a/poem-openapi-derive/Cargo.toml
+++ b/poem-openapi-derive/Cargo.toml
@@ -22,7 +22,7 @@ quote = "1.0.9"
 syn = { version = "1.0.77", features = ["full", "visit-mut"] }
 Inflector = "0.11.4"
 thiserror = "1.0.29"
-indexmap = "~1.6.2"                                            # https://github.com/tkaitchuck/aHash/issues/95
+indexmap = "1.8.2"
 regex = "1.5.5"
 http = "0.2.5"
 mime = "0.3.16"


### PR DESCRIPTION
Previously we locked the version of indexmap to `1.6.2` to help a user deal with https://github.com/tkaitchuck/aHash/issues/95 (see https://github.com/poem-web/poem/issues/258). Unfortunately this means that anyone who has up to date dependencies might run into issues preventing them from using this crate, because the deps require `> 1.8`.

For example:
```
$ cargo run
    Blocking waiting for file lock on package cache
    Updating git repository `https://github.com/banool/poem`
    Updating crates.io index
error: failed to select a version for `indexmap`.
    ... required by package `guppy v0.13.0`
    ... which satisfies dependency `guppy = "^0.13.0"` (locked to 0.13.0) of package `determinator v0.8.0`
    ... which satisfies dependency `determinator = "^0.8.0"` (locked to 0.8.0) of package `x v0.1.0 (/Users/dport/a/core/devtools/x)`
versions that meet the requirements `^1.8.0` are: 1.8.2, 1.8.1, 1.8.0

all possible versions conflict with previously selected packages.

  previously selected package `indexmap v1.6.2`
    ... which satisfies dependency `indexmap = "~1.6.2"` of package `poem-openapi-derive v1.3.29`
    ... which satisfies dependency `poem-openapi-derive = "^1.3.29"` of package `poem-openapi v1.3.29`
    ... which satisfies dependency `poem-openapi = "^1.3.29"` of package `aptos-node-checker v0.1.0 (/Users/dport/a/core/ecosystem/node-checker)`

failed to select a version for `indexmap` which could resolve this conflict
```

Pinning the version to `1.6.2` is something the users can do in their own Cargo.toml, the rest of us shouldn't be pinned to an old version by default.

This PR restores the version to the latest, `1.8.2`. Without this PR I can't use poem at all without forking it to make this change.

This will also help address https://github.com/poem-web/poem/issues/260.