### PR TITLE
Add support for returning OpenAPI spec as YAML

### DIFF
--- a/examples/openapi/union/src/main.rs
+++ b/examples/openapi/union/src/main.rs
@@ -39,13 +39,15 @@ async fn main() -> Result<(), std::io::Error> {
     let api_service = OpenApiService::new(Api, "Union", "1.0").server("http://localhost:3000/api");
     let ui = api_service.swagger_ui();
     let spec = api_service.spec_endpoint();
+    let spec_yaml = api_service.spec_endpoint_yaml();
 
     Server::new(TcpListener::bind("127.0.0.1:3000"))
         .run(
             Route::new()
                 .nest("/api", api_service)
                 .nest("/", ui)
-                .at("/spec", spec),
+                .at("/spec", spec)
+                .at("/spec_yaml", spec_yaml),
         )
         .await
 }

--- a/poem-openapi/Cargo.toml
+++ b/poem-openapi/Cargo.toml
@@ -31,6 +31,7 @@ poem = { path = "../poem", version = "1.3.30", features = [
 
 tokio = { version = "1.17.0", features = ["fs"] }
 serde_json = "1.0.68"
+serde_yaml = "0.8.24"
 serde_urlencoded = "0.7.1"
 base64 = "0.13.0"
 serde = { version = "1.0.130", features = ["derive"] }

--- a/poem-openapi/src/openapi.rs
+++ b/poem-openapi/src/openapi.rs
@@ -347,7 +347,7 @@ impl<T, W: ?Sized> OpenApiService<T, W> {
         crate::ui::redoc::create_endpoint(&self.spec())
     }
 
-    /// Create an endpoint to serve the open api specification.
+    /// Create an endpoint to serve the open api specification as JSON.
     pub fn spec_endpoint(&self) -> impl Endpoint
     where
         T: OpenApi,
@@ -357,6 +357,21 @@ impl<T, W: ?Sized> OpenApiService<T, W> {
         make_sync(move |_| {
             Response::builder()
                 .content_type("application/json")
+                .body(spec.clone())
+        })
+    }
+
+    /// Create an endpoint to serve the open api specification as YAML.
+    pub fn spec_endpoint_yaml(&self) -> impl Endpoint
+    where
+        T: OpenApi,
+        W: Webhook,
+    {
+        let spec = self.spec_yaml();
+        make_sync(move |_| {
+            Response::builder()
+                .content_type("application/x-yaml")
+                .header("Content-Disposition", "inline; filename=\"spec.yaml\"")
                 .body(spec.clone())
         })
     }
@@ -433,7 +448,7 @@ impl<T, W: ?Sized> OpenApiService<T, W> {
         doc
     }
 
-    /// Returns the OAS specification file.
+    /// Returns the OAS specification file as JSON.
     pub fn spec(&self) -> String
     where
         T: OpenApi,
@@ -441,6 +456,16 @@ impl<T, W: ?Sized> OpenApiService<T, W> {
     {
         let doc = self.document();
         serde_json::to_string_pretty(&doc).unwrap()
+    }
+
+    /// Returns the OAS specification file as YAML.
+    pub fn spec_yaml(&self) -> String
+    where
+        T: OpenApi,
+        W: Webhook,
+    {
+        let doc = self.document();
+        serde_yaml::to_string(&doc).unwrap()
     }
 }
 


### PR DESCRIPTION
## Summary
This is a nice convenience to offer users who need their spec as YAML, rather forcing them to take the JSON and convert it to YAML (which can be unreliable).

## Test Plan
```
cd examples/openapi/union
cargo run
```
Now go visit http://127.0.01:3000/docs/spec_yaml and see that it returns a YAML version of the spec.

I likely need to add some unit tests for this, but first I'll wait for the maintainers to give the green tick on this idea in general.

Thanks!