### PR TITLE
Add optional support for humantime Duration in poem Object

### DIFF
--- a/poem-openapi/Cargo.toml
+++ b/poem-openapi/Cargo.toml
@@ -53,6 +53,7 @@ uuid = { version = "0.8.2", optional = true }
 url = { version = "2.2.2", optional = true }
 bson = { version = "2.0.0", optional = true }
 rust_decimal = { version = "1.22.0", optional = true }
+humantime = { version = "2.1.0", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.17.0", features = ["macros", "rt-multi-thread"] }

--- a/poem-openapi/src/lib.rs
+++ b/poem-openapi/src/lib.rs
@@ -93,7 +93,8 @@
 //!
 //! | Feature    | Description |
 //! |------------|-----------------------------------------------------------------------|
-//! | chrono     | Integrate with the [`chrono` crate](https://crates.io/crates/chrono). |
+//! | chrono     | Integrate with the [`chrono` crate](https://crates.io/crates/chrono) |
+//! | humantime  | Integrate with the [`humantime` crate](https://crates.io/crates/humantime) |
 //! | swagger-ui | Add swagger UI support |
 //! | rapidoc    | Add RapiDoc UI support |
 //! | redoc      | Add Redoc UI support |

--- a/poem-openapi/src/types/external/humantime.rs
+++ b/poem-openapi/src/types/external/humantime.rs
@@ -1,8 +1,8 @@
 use std::borrow::Cow;
 
+use humantime::Duration;
 use poem::{http::HeaderValue, web::Field};
 use serde_json::Value;
-use humantime::Duration;
 
 use crate::{
     registry::{MetaSchema, MetaSchemaRef},

--- a/poem-openapi/src/types/external/humantime.rs
+++ b/poem-openapi/src/types/external/humantime.rs
@@ -1,0 +1,78 @@
+use std::borrow::Cow;
+
+use poem::{http::HeaderValue, web::Field};
+use serde_json::Value;
+use humantime::Duration;
+
+use crate::{
+    registry::{MetaSchema, MetaSchemaRef},
+    types::{
+        ParseError, ParseFromJSON, ParseFromMultipartField, ParseFromParameter, ParseResult,
+        ToHeader, ToJSON, Type,
+    },
+};
+
+impl Type for Duration {
+    const IS_REQUIRED: bool = true;
+
+    type RawValueType = Self;
+
+    type RawElementValueType = Self;
+
+    fn name() -> Cow<'static, str> {
+        "string(duration)".into()
+    }
+
+    fn schema_ref() -> MetaSchemaRef {
+        MetaSchemaRef::Inline(Box::new(MetaSchema::new_with_format("string", "duration")))
+    }
+
+    fn as_raw_value(&self) -> Option<&Self::RawValueType> {
+        Some(self)
+    }
+
+    fn raw_element_iter<'a>(
+        &'a self,
+    ) -> Box<dyn Iterator<Item = &'a Self::RawElementValueType> + 'a> {
+        Box::new(self.as_raw_value().into_iter())
+    }
+}
+
+impl ParseFromJSON for Duration {
+    fn parse_from_json(value: Option<Value>) -> ParseResult<Self> {
+        let value = value.unwrap_or_default();
+        if let Value::String(value) = value {
+            Ok(value.parse()?)
+        } else {
+            Err(ParseError::expected_type(value))
+        }
+    }
+}
+
+impl ParseFromParameter for Duration {
+    fn parse_from_parameter(value: &str) -> ParseResult<Self> {
+        value.parse().map_err(ParseError::custom)
+    }
+}
+
+#[poem::async_trait]
+impl ParseFromMultipartField for Duration {
+    async fn parse_from_multipart(field: Option<Field>) -> ParseResult<Self> {
+        match field {
+            Some(field) => Ok(field.text().await?.parse()?),
+            None => Err(ParseError::expected_input()),
+        }
+    }
+}
+
+impl ToJSON for Duration {
+    fn to_json(&self) -> Option<Value> {
+        Some(Value::String(self.to_string()))
+    }
+}
+
+impl ToHeader for Duration {
+    fn to_header(&self) -> Option<HeaderValue> {
+        HeaderValue::from_str(&self.to_string()).ok()
+    }
+}

--- a/poem-openapi/src/types/external/mod.rs
+++ b/poem-openapi/src/types/external/mod.rs
@@ -11,6 +11,8 @@ mod decimal;
 mod floats;
 mod hashmap;
 mod hashset;
+#[cfg(feature = "humantime")]
+mod humantime;
 mod integers;
 mod optional;
 mod regex;


### PR DESCRIPTION
I would love to be able to represent durations as part of the OpenAPI spec. As it is now you have to just make a field like "duration_secs" and trust the user will pass the value in as seconds. With this, you can instead get the rich parsing from humantime.

Naturally I made this an optional feature.

Tested with:
```
cargo test --features humantime
```

I see the other external types largely don't have tests so I didn't write specific tests for this either.