### PR TITLE
Add optional support for YAML as a general request payload

### DIFF
--- a/poem-openapi/Cargo.toml
+++ b/poem-openapi/Cargo.toml
@@ -27,6 +27,7 @@ poem = { path = "../poem", version = "1.3.33", features = [
   "tempfile",
   "cookie",
   "sse",
+  "yaml",
 ] }
 
 tokio = { version = "1.17.0", features = ["fs"] }

--- a/poem-openapi/src/payload/mod.rs
+++ b/poem-openapi/src/payload/mod.rs
@@ -9,12 +9,13 @@ mod html;
 mod json;
 mod plain_text;
 mod response;
+mod yaml;
 
 use poem::{Request, RequestBody, Result};
 
 pub use self::{
     attachment::Attachment, base64_payload::Base64, binary::Binary, event_stream::EventStream,
-    form::Form, html::Html, json::Json, plain_text::PlainText, response::Response,
+    form::Form, html::Html, json::Json, plain_text::PlainText, response::Response, yaml::Yaml,
 };
 use crate::registry::{MetaSchemaRef, Registry};
 

--- a/poem-openapi/src/payload/yaml.rs
+++ b/poem-openapi/src/payload/yaml.rs
@@ -1,0 +1,92 @@
+use std::ops::{Deref, DerefMut};
+
+use poem::{FromRequest, IntoResponse, Request, RequestBody, Response, Result};
+use serde_yaml::Value;
+
+use crate::{
+    error::ParseRequestPayloadError,
+    payload::{ParsePayload, Payload},
+    registry::{MetaMediaType, MetaResponse, MetaResponses, MetaSchemaRef, Registry},
+    types::{ParseFromYAML, ToYAML, Type},
+    ApiResponse,
+};
+
+/// A YAML payload.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct Yaml<T>(pub T);
+
+impl<T> Deref for Yaml<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for Yaml<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<T: Type> Payload for Yaml<T> {
+    const CONTENT_TYPE: &'static str = "application/x-yaml";
+
+    fn schema_ref() -> MetaSchemaRef {
+        T::schema_ref()
+    }
+
+    #[allow(unused_variables)]
+    fn register(registry: &mut Registry) {
+        T::register(registry);
+    }
+}
+
+#[poem::async_trait]
+impl<T: ParseFromYAML> ParsePayload for Yaml<T> {
+    const IS_REQUIRED: bool = true;
+
+    async fn from_request(request: &Request, body: &mut RequestBody) -> Result<Self> {
+        let data: Vec<u8> = FromRequest::from_request(request, body).await?;
+        let value = if data.is_empty() {
+            Value::Null
+        } else {
+            serde_yaml::from_slice(&data).map_err(|err| ParseRequestPayloadError {
+                reason: err.to_string(),
+            })?
+        };
+
+        let value = T::parse_from_yaml(Some(value)).map_err(|err| ParseRequestPayloadError {
+            reason: err.into_message(),
+        })?;
+        Ok(Self(value))
+    }
+}
+
+impl<T: ToYAML> IntoResponse for Yaml<T> {
+    fn into_response(self) -> Response {
+        poem::web::Yaml(self.0.to_yaml()).into_response()
+    }
+}
+
+impl<T: ToYAML> ApiResponse for Yaml<T> {
+    fn meta() -> MetaResponses {
+        MetaResponses {
+            responses: vec![MetaResponse {
+                description: "",
+                status: Some(200),
+                content: vec![MetaMediaType {
+                    content_type: Self::CONTENT_TYPE,
+                    schema: Self::schema_ref(),
+                }],
+                headers: vec![],
+            }],
+        }
+    }
+
+    fn register(registry: &mut Registry) {
+        T::register(registry);
+    }
+}
+
+impl_apirequest_for_payload!(Yaml<T>, T: ParseFromYAML);

--- a/poem/Cargo.toml
+++ b/poem/Cargo.toml
@@ -61,6 +61,7 @@ acme = [
 ]
 embed = ["rust-embed", "hex", "mime_guess"]
 xml = ["quick-xml"]
+yaml = ["serde_yaml"]
 
 [dependencies]
 poem-derive = { path = "../poem-derive", version = "1.3.33" }
@@ -128,6 +129,7 @@ libopentelemetry = { package = "opentelemetry", version = "0.17.0", features = [
 ], optional = true }
 libtempfile = { package = "tempfile", version = "3.2.0", optional = true }
 priority-queue = { version = "1.2.0", optional = true }
+serde_yaml = { version = "0.8.25", optional = true }
 tokio-native-tls = { version = "0.3.0", optional = true }
 tokio-openssl = { version = "0.6.3", optional = true }
 openssl = { version = "0.10", optional = true }

--- a/poem/src/error.rs
+++ b/poem/src/error.rs
@@ -670,6 +670,28 @@ impl ResponseError for MissingJsonContentTypeError {
     }
 }
 
+/// A possible error value when parsing YAML.
+#[derive(Debug, thiserror::Error)]
+#[error("parse: {0}")]
+pub struct ParseYamlError(#[from] pub serde_yaml::Error);
+
+impl ResponseError for ParseYamlError {
+    fn status(&self) -> StatusCode {
+        StatusCode::BAD_REQUEST
+    }
+}
+
+/// A missing yaml Content-Type error value when parsing header.
+#[derive(Debug, thiserror::Error)]
+#[error("Missing `Content-Type: application/x-yaml`")]
+pub struct MissingYamlContentTypeError;
+
+impl ResponseError for MissingYamlContentTypeError {
+    fn status(&self) -> StatusCode {
+        StatusCode::UNSUPPORTED_MEDIA_TYPE
+    }
+}
+
 /// A possible error value when parsing XML.
 #[cfg(feature = "xml")]
 #[derive(Debug, thiserror::Error)]

--- a/poem/src/test/request_builder.rs
+++ b/poem/src/test/request_builder.rs
@@ -119,6 +119,15 @@ impl<'a, E> TestRequestBuilder<'a, E> {
             .body(serde_json::to_string(&body).expect("valid json"))
     }
 
+    /// Sets the YAML body for this request with `application/x-yaml` content
+    /// type.
+    #[cfg(feature = "yaml")]
+    #[must_use]
+    pub fn body_yaml(self, body: &impl Serialize) -> Self {
+        self.content_type("application/x-yaml")
+            .body(serde_yaml::to_string(&body).expect("valid yaml"))
+    }
+
     /// Sets the XML body for this request with `application/xml` content
     /// type.
     #[cfg(feature = "xml")]

--- a/poem/src/test/response.rs
+++ b/poem/src/test/response.rs
@@ -158,6 +158,19 @@ impl TestResponse {
         );
     }
 
+    #[cfg(feature = "yaml")]
+    /// Asserts that the response body is JSON and it equals to `json`.
+    pub async fn assert_yaml(self, yaml: impl Serialize) {
+        assert_eq!(
+            self.0
+                .into_body()
+                .into_yaml::<serde_yaml::Value>()
+                .await
+                .expect("expect body"),
+            serde_yaml::to_value(yaml).expect("valid yaml")
+        );
+    }
+
     /// Asserts that the response body is XML and it equals to `xml`.
     #[cfg(feature = "xml")]
     pub async fn assert_xml(self, xml: impl Serialize) {
@@ -172,6 +185,15 @@ impl TestResponse {
         self.0
             .into_body()
             .into_json::<TestJson>()
+            .await
+            .expect("expect body")
+    }
+
+    /// Consumes this object and return the [`TestJson`].
+    pub async fn yaml(self) -> TestYaml {
+        self.0
+            .into_body()
+            .into_yaml::<TestYaml>()
             .await
             .expect("expect body")
     }

--- a/poem/src/web/mod.rs
+++ b/poem/src/web/mod.rs
@@ -32,6 +32,8 @@ mod typed_header;
 #[cfg(feature = "websocket")]
 #[cfg_attr(docsrs, doc(cfg(feature = "websocket")))]
 pub mod websocket;
+#[cfg(feature = "yaml")]
+mod yaml;
 
 use std::{convert::Infallible, fmt::Debug};
 
@@ -51,6 +53,8 @@ pub use self::static_file::{StaticFileRequest, StaticFileResponse};
 pub use self::tempfile::TempFile;
 #[cfg(feature = "xml")]
 pub use self::xml::Xml;
+#[cfg(feature = "yaml")]
+pub use self::yaml::Yaml;
 pub use self::{
     addr::{LocalAddr, RemoteAddr},
     data::Data,
@@ -903,6 +907,19 @@ mod tests {
             resp.into_body().into_string().await.unwrap(),
             r#"{"a":1,"b":2}"#
         );
+
+        // YAML
+        #[cfg(feature = "yaml")]
+        {
+            let sample_yaml = "---\nx: 1.0\ny: 2.0\n";
+            let resp = Yaml(serde_yaml::from_str(sample_yaml)).into_response();
+            assert_eq!(resp.status(), StatusCode::OK);
+            assert_eq!(
+                resp.content_type(),
+                Some("application/x-yaml; charset=utf-8")
+            );
+            assert_eq!(resp.into_body().into_string().await.unwrap(), sample_yaml,);
+        }
 
         #[cfg(feature = "xml")]
         {

--- a/poem/src/web/yaml.rs
+++ b/poem/src/web/yaml.rs
@@ -1,0 +1,221 @@
+use std::ops::{Deref, DerefMut};
+
+use http::StatusCode;
+use serde::{de::DeserializeOwned, Serialize};
+
+use crate::{
+    error::{MissingYamlContentTypeError, ParseYamlError},
+    http::header,
+    web::RequestBody,
+    FromRequest, IntoResponse, Request, Response, Result,
+};
+
+/// YAML extractor and response.
+///
+/// To extract the specified type of YAML from the body, `T` must implement
+/// [`serde::Deserialize`].
+///
+/// # Errors
+///
+/// - [`ReadBodyError`](crate::error::ReadBodyError)
+/// - [`ParseYamlError`]
+///
+/// ```
+/// use poem::{
+///     handler,
+///     http::{header, Method, StatusCode},
+///     post,
+///     test::TestClient,
+///     web::Yaml,
+///     Endpoint, Request, Route,
+/// };
+/// use serde::Deserialize;
+///
+/// #[derive(Deserialize)]
+/// struct User {
+///     name: String,
+/// }
+///
+/// #[handler]
+/// async fn index(Yaml(user): Yaml<User>) -> String {
+///     format!("welcome {}!", user.name)
+/// }
+///
+/// let app = Route::new().at("/", post(index));
+/// let cli = TestClient::new(app);
+///
+/// # tokio::runtime::Runtime::new().unwrap().block_on(async {
+/// let resp = cli
+///     .post("/")
+///     .header(header::CONTENT_TYPE, "application/x-yaml")
+///     .body(r#"---\nx: 1.0\ny: 2.0\n"#)
+///     .send()
+///     .await;
+/// resp.assert_status_is_ok();
+/// resp.assert_text("welcome foo!").await;
+/// # });
+/// ```
+///
+/// # Response
+///
+/// To serialize the specified type to YAML, `T` must implement
+/// [`serde::Serialize`].
+///
+/// ```
+/// use poem::{
+///     get, handler, http::StatusCode, test::TestClient, web::Yaml, Endpoint, Request, Route,
+/// };
+/// use serde::Serialize;
+///
+/// #[derive(Serialize)]
+/// struct User {
+///     name: String,
+/// }
+///
+/// #[handler]
+/// async fn index() -> Yaml<User> {
+///     Yaml(User {
+///         name: "foo".to_string(),
+///     })
+/// }
+///
+/// let app = Route::new().at("/", get(index));
+/// let cli = TestClient::new(app);
+///
+/// # tokio::runtime::Runtime::new().unwrap().block_on(async {
+/// let resp = cli.get("/").send().await;
+/// resp.assert_status_is_ok();
+/// resp.assert_text(r#"{"name":"foo"}"#).await;
+/// # });
+/// ```
+#[derive(Debug, Clone, Eq, PartialEq, Default)]
+pub struct Yaml<T>(pub T);
+
+impl<T> Deref for Yaml<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for Yaml<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+#[async_trait::async_trait]
+impl<'a, T: DeserializeOwned> FromRequest<'a> for Yaml<T> {
+    async fn from_request(req: &'a Request, body: &mut RequestBody) -> Result<Self> {
+        if is_yaml_content_type(req) {
+            let data = body.take()?.into_bytes().await?;
+            Ok(Self(serde_yaml::from_slice(&data).map_err(ParseYamlError)?))
+        } else {
+            Err(MissingYamlContentTypeError.into())
+        }
+    }
+}
+
+fn is_yaml_content_type(req: &Request) -> bool {
+    match req
+        .header(header::CONTENT_TYPE)
+        .and_then(|value| value.parse::<mime::Mime>().ok())
+    {
+        // the content-type should be `application/x-yaml`
+        Some(content_type)
+            if content_type.type_() == "application"
+                && (content_type.subtype() == "x-yaml"
+                    || content_type.suffix().map_or(false, |v| v == "yaml")) =>
+        {
+            true
+        }
+        _ => false,
+    }
+}
+
+impl<T: Serialize + Send> IntoResponse for Yaml<T> {
+    fn into_response(self) -> Response {
+        let data = match serde_yaml::to_vec(&self.0) {
+            Ok(data) => data,
+            Err(err) => {
+                return Response::builder()
+                    .status(StatusCode::INTERNAL_SERVER_ERROR)
+                    .body(err.to_string())
+            }
+        };
+        Response::builder()
+            .header(header::CONTENT_TYPE, "application/x-yaml; charset=utf-8")
+            .body(data)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::{Deserialize, Serialize};
+
+    use super::*;
+    use crate::{handler, test::TestClient};
+
+    #[derive(Deserialize, Serialize, Debug, Eq, PartialEq)]
+    struct CreateResource {
+        name: String,
+        value: i32,
+    }
+
+    #[tokio::test]
+    async fn test_yaml_extractor() {
+        #[handler(internal)]
+        async fn index(query: Yaml<CreateResource>) {
+            assert_eq!(query.name, "abc");
+            assert_eq!(query.value, 100);
+        }
+
+        let cli = TestClient::new(index);
+        let yaml = serde_yaml::from_str(r#"---\nx: 1.0\ny: 2.0\n"#).unwrap();
+        cli.post("/")
+            .body_yaml(&yaml) // body_yaml has already set request with `application/x-yaml` content type
+            .send()
+            .await
+            .assert_status_is_ok();
+    }
+    #[tokio::test]
+    async fn test_yaml_extractor_fail() {
+        #[handler(internal)]
+        async fn index(query: Yaml<CreateResource>) {
+            assert_eq!(query.name, "abc");
+            assert_eq!(query.value, 100);
+        }
+        let create_resource = CreateResource {
+            name: "abc".to_string(),
+            value: 100,
+        };
+        let cli = TestClient::new(index);
+        cli.post("/")
+            // .header(header::CONTENT_TYPE, "application/x-yaml")
+            .body(serde_yaml::to_string(&create_resource).expect("Invalid yaml"))
+            .send()
+            .await
+            .assert_status(StatusCode::UNSUPPORTED_MEDIA_TYPE);
+    }
+
+    #[tokio::test]
+    async fn test_yaml_response() {
+        #[handler(internal)]
+        async fn index() -> Yaml<CreateResource> {
+            Yaml(CreateResource {
+                name: "abc".to_string(),
+                value: 100,
+            })
+        }
+
+        let cli = TestClient::new(index);
+        let resp = cli.get("/").send().await;
+        resp.assert_status_is_ok();
+        resp.assert_yaml(&CreateResource {
+            name: "abc".to_string(),
+            value: 100,
+        })
+        .await;
+    }
+}


### PR DESCRIPTION
This PR adds support for YAML, in all the same ways that there is support for JSON. For the most part I just copied what we do for JSON, but with `serde_yaml`, which is mostly a drop in replacement.

In `poem` itself this is an optional feature, but given we already import `serde_yaml` in `poem-openapi`, I made it just include the YAML payload stuff by default.

Still a work in progress.