### PR TITLE
Return 400 when parsing path fails, not 404

### DIFF
--- a/poem-openapi/src/error.rs
+++ b/poem-openapi/src/error.rs
@@ -33,7 +33,7 @@ pub struct ParsePathError {
 
 impl ResponseError for ParsePathError {
     fn status(&self) -> StatusCode {
-        StatusCode::NOT_FOUND
+        StatusCode::BAD_REQUEST
     }
 }
 


### PR DESCRIPTION
All the other parse errors return 400, but this one returns 404. This PR makes it conform to the other parse errors.