### PR TITLE
Add response types related to streaming Bytes

### DIFF
--- a/examples/poem/stream-response/Cargo.toml
+++ b/examples/poem/stream-response/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "example-stream-response"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+futures-util = "0.3.21"
+poem = { path = "../../../poem" }
+reqwest = { version = "0.11.11", features = ["stream"] }
+tokio = { version = "1.17.0", features = ["rt-multi-thread", "macros"] }
+tracing-subscriber = { version ="0.3.9", features = ["env-filter"] }

--- a/examples/poem/stream-response/src/main.rs
+++ b/examples/poem/stream-response/src/main.rs
@@ -1,0 +1,35 @@
+use futures_util::StreamExt;
+use poem::{
+    get, handler,
+    listener::TcpListener,
+    middleware::Tracing,
+    web::{stream::StreamResponse, Path},
+    EndpointExt, IntoResponse, Route, Server,
+};
+use reqwest::StatusCode;
+
+#[handler]
+async fn dex(Path(id_or_name): Path<String>) -> (StatusCode, impl IntoResponse) {
+    let endpoint = format!("https://pokeapi.co/api/v2/pokemon/{}", id_or_name);
+    let res = reqwest::get(endpoint).await.unwrap();
+    let status = res.status();
+    let st = res.bytes_stream().map(|item| item.unwrap());
+    (
+        status,
+        StreamResponse::new(st).with_content_type("application/json"),
+    )
+}
+
+#[tokio::main]
+async fn main() -> Result<(), std::io::Error> {
+    if std::env::var_os("RUST_LOG").is_none() {
+        std::env::set_var("RUST_LOG", "poem=debug");
+    }
+    tracing_subscriber::fmt::init();
+
+    let app = Route::new().at("/dex/:id_or_name", get(dex)).with(Tracing);
+    Server::new(TcpListener::bind("127.0.0.1:3000"))
+        .name("poke-proxy")
+        .run(app)
+        .await
+}

--- a/poem-openapi/src/payload/json_proxy_stream.rs
+++ b/poem-openapi/src/payload/json_proxy_stream.rs
@@ -1,0 +1,66 @@
+use bytes::Bytes;
+use futures_util::{stream::BoxStream, Stream, StreamExt};
+use poem::{web::stream::StreamResponse, IntoResponse, Response};
+
+use crate::{
+    payload::Payload,
+    registry::{MetaMediaType, MetaResponse, MetaResponses, MetaSchemaRef, Registry},
+    types::{ToJSON, Type},
+    ApiResponse,
+};
+
+/// A Json payload from a `Stream` of  `Bytes`.
+pub struct JsonProxyStream<P> {
+    stream: BoxStream<'static, Bytes>,
+    _proxy: std::marker::PhantomData<P>,
+}
+
+impl<P> JsonProxyStream<P> {
+    /// Create a Json payload from a Bytes Stream using a proxy type for schema.
+    pub fn new(stream: impl Stream<Item = Bytes> + Send + 'static) -> Self {
+        Self {
+            stream: stream.boxed(),
+            _proxy: std::marker::PhantomData::default(),
+        }
+    }
+}
+
+impl<P: Type + ToJSON> Payload for JsonProxyStream<P> {
+    const CONTENT_TYPE: &'static str = "application/json";
+
+    fn schema_ref() -> MetaSchemaRef {
+        P::schema_ref()
+    }
+
+    fn register(registry: &mut Registry) {
+        P::register(registry);
+    }
+}
+
+impl<P: Type + ToJSON> IntoResponse for JsonProxyStream<P> {
+    fn into_response(self) -> Response {
+        StreamResponse::new(self.stream)
+            .with_content_type(Self::CONTENT_TYPE)
+            .into_response()
+    }
+}
+
+impl<P: Type + ToJSON> ApiResponse for JsonProxyStream<P> {
+    fn meta() -> MetaResponses {
+        MetaResponses {
+            responses: vec![MetaResponse {
+                description: "",
+                status: Some(200),
+                content: vec![MetaMediaType {
+                    content_type: Self::CONTENT_TYPE,
+                    schema: Self::schema_ref(),
+                }],
+                headers: vec![],
+            }],
+        }
+    }
+
+    fn register(registry: &mut Registry) {
+        P::register(registry);
+    }
+}

--- a/poem-openapi/src/payload/mod.rs
+++ b/poem-openapi/src/payload/mod.rs
@@ -7,6 +7,7 @@ mod event_stream;
 mod form;
 mod html;
 mod json;
+mod json_proxy_stream;
 mod plain_text;
 mod response;
 
@@ -14,7 +15,8 @@ use poem::{Request, RequestBody, Result};
 
 pub use self::{
     attachment::Attachment, base64_payload::Base64, binary::Binary, event_stream::EventStream,
-    form::Form, html::Html, json::Json, plain_text::PlainText, response::Response,
+    form::Form, html::Html, json::Json, json_proxy_stream::JsonProxyStream, plain_text::PlainText,
+    response::Response,
 };
 use crate::registry::{MetaHeader, MetaSchemaRef, Registry};
 

--- a/poem/src/web/mod.rs
+++ b/poem/src/web/mod.rs
@@ -21,6 +21,7 @@ mod redirect;
 pub mod sse;
 #[cfg(feature = "static-files")]
 mod static_file;
+pub mod stream;
 #[cfg(feature = "tempfile")]
 mod tempfile;
 #[cfg(feature = "xml")]

--- a/poem/src/web/stream/mod.rs
+++ b/poem/src/web/stream/mod.rs
@@ -1,0 +1,4 @@
+//! Streaming request/response types.
+mod response;
+
+pub use self::response::StreamResponse;

--- a/poem/src/web/stream/response.rs
+++ b/poem/src/web/stream/response.rs
@@ -1,0 +1,90 @@
+use bytes::Bytes;
+use futures_util::{stream::BoxStream, Stream, StreamExt};
+
+use crate::{Body, IntoResponse, Response};
+
+/// A Bytes streaming response.
+///
+/// # Example
+///
+/// ```
+/// use bytes::Bytes;
+/// use futures_util::stream;
+/// use poem::{
+///     handler,
+///     test::TestClient,
+///     web::stream::StreamResponse,
+/// };
+///
+/// #[handler]
+/// fn index() -> StreamResponse {
+///     StreamResponse::new(stream::iter(vec![
+///         Bytes::from("abc"),
+///         Bytes::from("def"),
+///         Bytes::from("ghi"),
+///     ]))
+/// }
+///
+/// let cli = TestClient::new(index);
+///
+/// # tokio::runtime::Runtime::new().unwrap().block_on(async {
+/// let resp = cli.get("/").send().await;
+/// resp.assert_status_is_ok();
+/// resp.assert_text("abcdefghi").await;
+/// # });
+/// ```
+pub struct StreamResponse {
+    stream: BoxStream<'static, Bytes>,
+}
+
+impl StreamResponse {
+    /// Creates a response from a stream of Bytes.
+    pub fn new(stream: impl Stream<Item = Bytes> + Send + 'static) -> Self {
+        Self {
+            stream: stream.boxed(),
+        }
+    }
+}
+
+impl IntoResponse for StreamResponse {
+    fn into_response(self) -> Response {
+        let stream = self
+            .stream
+            .map(|chunk| Ok::<_, std::io::Error>(chunk))
+            .boxed();
+
+        Response::builder()
+            .content_type("application/octet-stream")
+            .body(Body::from_async_read(tokio_util::io::StreamReader::new(
+                stream,
+            )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_create() {
+        let st = futures_util::stream::iter([Bytes::from("abc"), Bytes::from("def")].into_iter());
+        let res = StreamResponse::new(st).into_response();
+        assert_eq!(res.content_type().unwrap(), "application/octet-stream");
+        assert_eq!(res.into_body().into_string().await.unwrap(), "abcdef");
+    }
+
+    #[tokio::test]
+    async fn test_custom_content_type() {
+        let st = futures_util::stream::iter(
+            [Bytes::from(r#""abc"#), Bytes::from(r#"def""#)].into_iter(),
+        );
+        let res = StreamResponse::new(st)
+            .with_content_type("application/json")
+            .into_response();
+        assert_eq!(res.content_type().unwrap(), "application/json");
+        assert_eq!(
+            res.into_body().into_json::<String>().await.unwrap(),
+            "abcdef"
+        );
+    }
+}


### PR DESCRIPTION
I had to implement something similar to this for an internal facade service at work,
and would like to push it upstream.
It creates helper types to use streams of `Bytes` as the response of a handler in `poem` and `poem-openapi`.
Please, feel free to criticize the implementation and naming schemes.