### PR TITLE
Use Parent_Child instead of Parent[Child] for generated intermediate type

### DIFF
--- a/poem-openapi-derive/src/union.rs
+++ b/poem-openapi-derive/src/union.rs
@@ -78,7 +78,7 @@ pub(crate) fn generate(args: DeriveInput) -> GeneratorResult<TokenStream> {
             1 => {
                 let object_ty = &variant.fields.fields[0];
                 let schema_name = quote! {
-                    ::std::format!("{}[{}]", <Self as #crate_name::types::Type>::name(), <#object_ty as #crate_name::types::Type>::name())
+                    ::std::format!("{}_{}", <Self as #crate_name::types::Type>::name(), <#object_ty as #crate_name::types::Type>::name())
                 };
                 let mapping_name = match &variant.mapping {
                     Some(mapping) => quote!(::std::string::ToString::to_string(#mapping)),

--- a/poem-openapi/tests/union.rs
+++ b/poem-openapi/tests/union.rs
@@ -49,19 +49,19 @@ fn with_discriminator() {
             discriminator: Some(MetaDiscriminatorObject {
                 property_name: "type",
                 mapping: vec![
-                    ("A".to_string(), "#/components/schemas/MyObj[A]".to_string()),
-                    ("B".to_string(), "#/components/schemas/MyObj[B]".to_string()),
+                    ("A".to_string(), "#/components/schemas/MyObj_A".to_string()),
+                    ("B".to_string(), "#/components/schemas/MyObj_B".to_string()),
                 ]
             }),
             any_of: vec![
-                MetaSchemaRef::Reference("MyObj[A]".to_string()),
-                MetaSchemaRef::Reference("MyObj[B]".to_string()),
+                MetaSchemaRef::Reference("MyObj_A".to_string()),
+                MetaSchemaRef::Reference("MyObj_B".to_string()),
             ],
             ..MetaSchema::ANY
         }
     );
 
-    let schema_myobj_a = get_meta_by_name::<MyObj>("MyObj[A]");
+    let schema_myobj_a = get_meta_by_name::<MyObj>("MyObj_A");
     assert_eq!(
         schema_myobj_a,
         MetaSchema {
@@ -83,7 +83,7 @@ fn with_discriminator() {
         }
     );
 
-    let schema_myobj_b = get_meta_by_name::<MyObj>("MyObj[B]");
+    let schema_myobj_b = get_meta_by_name::<MyObj>("MyObj_B");
     assert_eq!(
         schema_myobj_b,
         MetaSchema {
@@ -181,19 +181,19 @@ fn with_discriminator_mapping() {
             discriminator: Some(MetaDiscriminatorObject {
                 property_name: "type",
                 mapping: vec![
-                    ("c".to_string(), "#/components/schemas/MyObj[A]".to_string()),
-                    ("d".to_string(), "#/components/schemas/MyObj[B]".to_string()),
+                    ("c".to_string(), "#/components/schemas/MyObj_A".to_string()),
+                    ("d".to_string(), "#/components/schemas/MyObj_B".to_string()),
                 ]
             }),
             any_of: vec![
-                MetaSchemaRef::Reference("MyObj[A]".to_string()),
-                MetaSchemaRef::Reference("MyObj[B]".to_string()),
+                MetaSchemaRef::Reference("MyObj_A".to_string()),
+                MetaSchemaRef::Reference("MyObj_B".to_string()),
             ],
             ..MetaSchema::ANY
         }
     );
 
-    let schema_myobj_a = get_meta_by_name::<MyObj>("MyObj[A]");
+    let schema_myobj_a = get_meta_by_name::<MyObj>("MyObj_A");
     assert_eq!(
         schema_myobj_a,
         MetaSchema {
@@ -215,7 +215,7 @@ fn with_discriminator_mapping() {
         }
     );
 
-    let schema_myobj_b = get_meta_by_name::<MyObj>("MyObj[B]");
+    let schema_myobj_b = get_meta_by_name::<MyObj>("MyObj_B");
     assert_eq!(
         schema_myobj_b,
         MetaSchema {


### PR DESCRIPTION
In the OpenAPI specification, it states that these are the only valid characters for a component name:
```
A..Z a..z 0..9 . _ -
```
From https://swagger.io/docs/specification/components/.

As such, Poem doesn't generate conformant component names right now. This PR changes the generation from `Parent[Child]` to `Parent_Child`. I feel this is the best option, `-` and `.` are generally special characters in some languages and that would make the client generation less predictable.

We should bump the minor version for this one since it's a breaking change.