### PR TITLE
Use LENGTH_REQUIRED instead of BAD_REQUEST in SizeLimit middleware

### DIFF
--- a/poem/src/error.rs
+++ b/poem/src/error.rs
@@ -884,7 +884,7 @@ pub enum SizedLimitError {
 impl ResponseError for SizedLimitError {
     fn status(&self) -> StatusCode {
         match self {
-            SizedLimitError::MissingContentLength => StatusCode::BAD_REQUEST,
+            SizedLimitError::MissingContentLength => StatusCode::LENGTH_REQUIRED,
             SizedLimitError::PayloadTooLarge => StatusCode::PAYLOAD_TOO_LARGE,
         }
     }

--- a/poem/src/middleware/size_limit.rs
+++ b/poem/src/middleware/size_limit.rs
@@ -5,7 +5,7 @@ use crate::{
 /// Middleware for limit the request payload size.
 ///
 /// If the incoming request does not contain the `Content-Length` header, it
-/// will return `BAD_REQUEST` status code.
+/// will return `LENGTH_REQUIRED` status code.
 ///
 /// # Errors
 ///
@@ -74,7 +74,7 @@ mod tests {
         cli.post("/")
             .send()
             .await
-            .assert_status(StatusCode::BAD_REQUEST);
+            .assert_status(StatusCode::LENGTH_REQUIRED);
 
         cli.post("/")
             .header("content-length", 6)


### PR DESCRIPTION
There is a specific error code for this case, let's use it.