### PR TITLE
Add `has_source` function to Error

### DIFF
--- a/poem/src/error.rs
+++ b/poem/src/error.rs
@@ -400,6 +400,11 @@ impl Error {
             AsResponse::Response(resp) => resp,
         }
     }
+
+    /// Returns whether the error has a source or not.
+    pub fn has_source(&self) -> bool {
+        self.source.is_some()
+    }
 }
 
 define_http_error!(


### PR DESCRIPTION
This would be helpful to me in the function I'm writing to use with `catch_all_errors`.