### PR TITLE
Add actual_type to schema registry

### DIFF
--- a/poem-openapi-derive/src/api.rs
+++ b/poem-openapi-derive/src/api.rs
@@ -372,8 +372,13 @@ fn generate_operation(
         });
     }
 
-    ctx.register_items
-        .push(quote!(<#res_ty as #crate_name::ApiResponse>::register(registry);));
+    if let Some(actual_type) = &actual_type {
+        ctx.register_items
+            .push(quote!(<#actual_type as #crate_name::ApiResponse>::register(registry);));
+    } else {
+        ctx.register_items
+            .push(quote!(<#res_ty as #crate_name::ApiResponse>::register(registry);));
+    }
 
     let transform = transform.map(|transform| {
         quote! {

--- a/poem-openapi-derive/src/response.rs
+++ b/poem-openapi-derive/src/response.rs
@@ -202,7 +202,11 @@ pub(crate) fn generate(args: DeriveInput) -> GeneratorResult<TokenStream> {
                         headers: ::std::vec![#(#meta_headers),*],
                     }
                 });
-                schemas.push(media_ty);
+                if let Some(actual_type) = variant.actual_type.as_ref() {
+                    schemas.push(actual_type);
+                } else {
+                    schemas.push(media_ty);
+                }
             }
             1 => {
                 // #[oai(status = 200)]
@@ -235,7 +239,11 @@ pub(crate) fn generate(args: DeriveInput) -> GeneratorResult<TokenStream> {
                         headers: ::std::vec![#(#meta_headers),*],
                     }
                 });
-                schemas.push(media_ty);
+                if let Some(actual_type) = variant.actual_type.as_ref() {
+                    schemas.push(actual_type);
+                } else {
+                    schemas.push(media_ty);
+                }
             }
             0 => {
                 // #[oai(status = 200)]

--- a/poem-openapi-derive/src/response_content.rs
+++ b/poem-openapi-derive/src/response_content.rs
@@ -106,7 +106,11 @@ pub(crate) fn generate(args: DeriveInput) -> GeneratorResult<TokenStream> {
                         schema: #schema_ref,
                     }
                 });
-                schemas.push(item_ty);
+                if let Some(actual_type) = &variant.actual_type {
+                    schemas.push(actual_type);
+                } else {
+                    schemas.push(item_ty);
+                };
             }
             _ => {
                 return Err(

--- a/poem-openapi/tests/api.rs
+++ b/poem-openapi/tests/api.rs
@@ -7,7 +7,7 @@ use poem::{
 use poem_openapi::{
     param::Query,
     payload::{Binary, Json, Payload, PlainText},
-    registry::{MetaApi, MetaExternalDocument, MetaOperation, MetaParamIn, MetaSchema},
+    registry::{MetaApi, MetaExternalDocument, MetaOperation, MetaParamIn, MetaSchema, Registry},
     types::Type,
     ApiRequest, ApiResponse, Object, OpenApi, OpenApiService, Tags,
 };
@@ -706,6 +706,11 @@ async fn actual_type() {
 
     resp.assert_content_type("application/json");
     resp.assert_json(&serde_json::json!({ "value": 100 })).await;
+
+    let mut registry = Registry::new();
+    Api::register(&mut registry);
+    let type_name: Vec<&String> = registry.schemas.keys().collect();
+    assert_eq!(&type_name, &["MyObj"]);
 }
 
 #[tokio::test]

--- a/poem-openapi/tests/response.rs
+++ b/poem-openapi/tests/response.rs
@@ -7,7 +7,9 @@ use poem::{
 };
 use poem_openapi::{
     payload::{Binary, Json, Payload, PlainText},
-    registry::{MetaApi, MetaMediaType, MetaResponse, MetaResponses, MetaSchema, MetaSchemaRef},
+    registry::{
+        MetaApi, MetaMediaType, MetaResponse, MetaResponses, MetaSchema, MetaSchemaRef, Registry,
+    },
     types::{ToJSON, Type},
     ApiResponse, Object, OpenApi, OpenApiService,
 };
@@ -490,4 +492,9 @@ async fn actual_type() {
 
     resp.assert_content_type("application/json");
     resp.assert_json(&serde_json::json!({ "value": 100 })).await;
+
+    let mut registry = Registry::new();
+    Api::register(&mut registry);
+    let type_name: Vec<&String> = registry.schemas.keys().collect();
+    assert_eq!(&type_name, &["MyObj"]);
 }

--- a/poem-openapi/tests/response_content.rs
+++ b/poem-openapi/tests/response_content.rs
@@ -1,7 +1,7 @@
 use poem::{http::StatusCode, test::TestClient, IntoResponse};
 use poem_openapi::{
     payload::{Binary, Json, Payload, PlainText},
-    registry::{MetaApi, MetaMediaType, MetaResponse, MetaResponses},
+    registry::{MetaApi, MetaMediaType, MetaResponse, MetaResponses, Registry},
     ApiResponse, Object, OpenApi, OpenApiService, ResponseContent,
 };
 
@@ -143,4 +143,9 @@ async fn actual_type() {
 
     resp.assert_content_type("application/json");
     resp.assert_json(&serde_json::json!({ "value": 100 })).await;
+
+    let mut registry = Registry::new();
+    Api::register(&mut registry);
+    let type_name: Vec<&String> = registry.schemas.keys().collect();
+    assert_eq!(&type_name, &["MyObj"]);
 }


### PR DESCRIPTION
This PR fixes the issue #365, where the `actual_type` attribute is not being added to the schema registry causing the API server to crash.