### PR TITLE
feat: Request to add poem-casbin in examples of community use

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The following are cases of community use:
 | [warpgate](https://github.com/eugeny/warpgate)                                   | A smart SSH bastion host that works with any SSH clients.                                                              | [(README)](https://github.com/warp-tech/warpgate/blob/main/README.md) |
 | [lust](https://github.com/ChillFish8/lust)                                       | A fast, auto-optimizing image server designed for high throughput and caching.                                         | [(README)](https://github.com/ChillFish8/lust/blob/master/README.md)  |
 | [aptos](https://github.com/aptos-labs/aptos-core)                                | Building the safest and most scalable Layer 1 blockchain.                                                              | [(WEBSITE)](https://aptoslabs.com/)                                   |
+| [poem-casbin](https://github.com/casbin-rs/poem-casbin)  | Casbin access control middleware for poem framework.                                                              | [(WEBSITE)](https://casbin.io/)                                   |
 
 
 ### Startups

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The following are cases of community use:
 | [warpgate](https://github.com/eugeny/warpgate)                                   | A smart SSH bastion host that works with any SSH clients.                                                              | [(README)](https://github.com/warp-tech/warpgate/blob/main/README.md) |
 | [lust](https://github.com/ChillFish8/lust)                                       | A fast, auto-optimizing image server designed for high throughput and caching.                                         | [(README)](https://github.com/ChillFish8/lust/blob/master/README.md)  |
 | [aptos](https://github.com/aptos-labs/aptos-core)                                | Building the safest and most scalable Layer 1 blockchain.                                                              | [(WEBSITE)](https://aptoslabs.com/)                                   |
-| [poem-casbin](https://github.com/casbin-rs/poem-casbin)  | Casbin access control middleware for poem framework.                                                              | [(WEBSITE)](https://casbin.io/)                                   |
+| [poem-casbin](https://github.com/casbin-rs/poem-casbin)  | Casbin access control middleware for poem framework.                                                              | [(WEBSITE)](https://casbin.org/)                                   |
 
 
 ### Startups


### PR DESCRIPTION
Currently, the rust version of Casbin is ready for production and we are developing the ecosystem around it. 

`poem-casbin` uses Axum web framework to build a basic middleware which can handle requests with authorization control. It can basically read username, request path, request method and send enforce request to casbin enforcer for authorization. 

I wish to add a pointer to its repository it in the showcase examples of your repository so that its accessible to the community