### PR TITLE
Provide some way to alter only framework errors 

### DIFF
--- a/poem/src/error.rs
+++ b/poem/src/error.rs
@@ -394,7 +394,7 @@ impl Error {
             },
             None => Err(Error {
                 as_response,
-                source: None,
+                source: self.source,
                 extensions,
             }),
         }


### PR DESCRIPTION
As it is now, if you downcast an error, the error disappears and the error message becomes "response". This is a start to trying to fix that, though I'm not sure yet if it fixes it completely. The use case is a function like this:
```
// Copyright (c) Aptos
// SPDX-License-Identifier: UNLICENSED

use crate::endpoints::{AptosTapError, AptosTapErrorCode};
use poem::{IntoResponse, Response};

use super::errors::AptosTapErrorResponse;

/// In the OpenAPI spec for this API, we say that every response we return will
/// be a JSON representation of AptosTapError. For our own errors, this is exactly
/// what we do. The problem is the Poem framework does not conform to this
/// format, it can return errors in a different format. The purpose of this
/// function is to catch those errors and convert them to the correct format.
pub async fn convert_error(error: poem::Error) -> impl poem::IntoResponse {
    // In the tap the only error we ever return ourselves is AptosTapError.
    // Therefore, if the error is a different type, it must be an error from
    // the Poem framework.
    match error.downcast::<AptosTapError>() {
        Ok(aptos_tap_error) => {
            println!("aptos_tap_error: {:?}", aptos_tap_error);
            AptosTapErrorResponse::from(aptos_tap_error).into_response()
        }
        Err(poem_error) => {
            let error_string = poem_error.to_string();
            build_error_response(error_string)
        }
    }
}

fn build_error_response(error_string: String) -> Response {
    AptosTapErrorResponse::from(AptosTapError::new_with_error_code(
        error_string,
        AptosTapErrorCode::WebFrameworkError,
    ))
    .into_response()
}
```