### PR TITLE
Fixes #448. opentelemetry_metrics: Correct duration conversion

### DIFF
--- a/poem/src/middleware/opentelemetry_metrics.rs
+++ b/poem/src/middleware/opentelemetry_metrics.rs
@@ -101,7 +101,7 @@ impl<E: Endpoint> Endpoint for OpenTelemetryMetricsEndpoint<E> {
 
         self.request_count.add(&cx, 1, &labels);
         self.duration
-            .record(&cx, elapsed.as_secs_f64() / 1000.0, &labels);
+            .record(&cx, elapsed.as_secs_f64() * 1000.0, &labels);
 
         res
     }


### PR DESCRIPTION
from seconds to milliseconds.

See https://github.com/poem-web/poem/issues/448