### PR TITLE
Add the missing feature `openapi-explorer` in `ui` mod

### DIFF
--- a/poem-openapi/src/lib.rs
+++ b/poem-openapi/src/lib.rs
@@ -131,7 +131,12 @@ pub mod validation;
 
 mod base;
 mod openapi;
-#[cfg(any(feature = "swagger-ui", feature = "rapidoc", feature = "redoc", feature = "openapi-explorer"))]
+#[cfg(any(
+    feature = "swagger-ui",
+    feature = "rapidoc",
+    feature = "redoc",
+    feature = "openapi-explorer"
+))]
 mod ui;
 
 pub use base::{

--- a/poem-openapi/src/lib.rs
+++ b/poem-openapi/src/lib.rs
@@ -131,7 +131,7 @@ pub mod validation;
 
 mod base;
 mod openapi;
-#[cfg(any(feature = "swagger-ui", feature = "rapidoc", feature = "redoc"))]
+#[cfg(any(feature = "swagger-ui", feature = "rapidoc", feature = "redoc", feature = "openapi-explorer"))]
 mod ui;
 
 pub use base::{


### PR DESCRIPTION
It's not work now
`poem-openapi = { version = "2.0.22", features = ["openapi-explorer"] }`
and must add another feature
`poem-openapi = { version = "2.0.22", features = ["openapi-explorer", "swagger-ui"] }`