### PR TITLE
fix errors when parse yaml & xml request

### DIFF
--- a/poem-openapi-derive/src/object.rs
+++ b/poem-openapi-derive/src/object.rs
@@ -447,6 +447,50 @@ pub(crate) fn generate(args: DeriveInput) -> GeneratorResult<TokenStream> {
                 ::std::option::Option::Some(#crate_name::__private::serde_json::Value::Object(object))
             }
         }
+
+        impl #impl_generics #crate_name::types::ParseFromXML for #ident #ty_generics #where_clause {
+            fn parse_from_xml(value: ::std::option::Option<#crate_name::__private::serde_json::Value>) -> ::std::result::Result<Self, #crate_name::types::ParseError<Self>> {
+                let value = value.unwrap_or_default();
+                match value {
+                    #crate_name::__private::serde_json::Value::Object(mut obj) => {
+                        #(#deserialize_fields)*
+                        #deny_unknown_fields
+                        ::std::result::Result::Ok(Self { #(#fields),* })
+                    }
+                    _ => ::std::result::Result::Err(#crate_name::types::ParseError::expected_type(value)),
+                }
+            }
+        }
+
+        impl #impl_generics #crate_name::types::ToXML for #ident #ty_generics #where_clause {
+            fn to_xml(&self) -> ::std::option::Option<#crate_name::__private::serde_json::Value> {
+                let mut object = #crate_name::__private::serde_json::Map::new();
+                #(#serialize_fields)*
+                ::std::option::Option::Some(#crate_name::__private::serde_json::Value::Object(object))
+            }
+        }
+
+        impl #impl_generics #crate_name::types::ParseFromYAML for #ident #ty_generics #where_clause {
+            fn parse_from_yaml(value: ::std::option::Option<#crate_name::__private::serde_json::Value>) -> ::std::result::Result<Self, #crate_name::types::ParseError<Self>> {
+                let value = value.unwrap_or_default();
+                match value {
+                    #crate_name::__private::serde_json::Value::Object(mut obj) => {
+                        #(#deserialize_fields)*
+                        #deny_unknown_fields
+                        ::std::result::Result::Ok(Self { #(#fields),* })
+                    }
+                    _ => ::std::result::Result::Err(#crate_name::types::ParseError::expected_type(value)),
+                }
+            }
+        }
+
+        impl #impl_generics #crate_name::types::ToYAML for #ident #ty_generics #where_clause {
+            fn to_yaml(&self) -> ::std::option::Option<#crate_name::__private::serde_json::Value> {
+                let mut object = #crate_name::__private::serde_json::Map::new();
+                #(#serialize_fields)*
+                ::std::option::Option::Some(#crate_name::__private::serde_json::Value::Object(object))
+            }
+        }
     };
 
     // remote

--- a/poem-openapi/src/payload/xml.rs
+++ b/poem-openapi/src/payload/xml.rs
@@ -59,9 +59,11 @@ impl<T: ParseFromXML> ParsePayload for Xml<T> {
         let value = if data.is_empty() {
             Value::Null
         } else {
-            serde_json::from_slice(&data).map_err(|err| ParseRequestPayloadError {
-                reason: err.to_string(),
-            })?
+            quick_xml::de::from_str(&String::from_utf8(data).unwrap_or_default()).map_err(
+                |err| ParseRequestPayloadError {
+                    reason: err.to_string(),
+                },
+            )?
         };
 
         let value = T::parse_from_xml(Some(value)).map_err(|err| ParseRequestPayloadError {

--- a/poem-openapi/src/payload/yaml.rs
+++ b/poem-openapi/src/payload/yaml.rs
@@ -59,7 +59,7 @@ impl<T: ParseFromYAML> ParsePayload for Yaml<T> {
         let value = if data.is_empty() {
             Value::Null
         } else {
-            serde_json::from_slice(&data).map_err(|err| ParseRequestPayloadError {
+            serde_yaml::from_slice(&data).map_err(|err| ParseRequestPayloadError {
                 reason: err.to_string(),
             })?
         };

--- a/poem-openapi/tests/response.rs
+++ b/poem-openapi/tests/response.rs
@@ -8,16 +8,17 @@ use poem::{
     Error, IntoResponse,
 };
 use poem_openapi::{
-    payload::{Binary, Json, Payload, PlainText},
+    payload::{Binary, Json, Payload, PlainText, Yaml},
     registry::{
         MetaApi, MetaMediaType, MetaResponse, MetaResponses, MetaSchema, MetaSchemaRef, Registry,
     },
     types::{ToJSON, Type},
     ApiResponse, Object, OpenApi, OpenApiService,
 };
+use serde::Deserialize;
 use serde_json::Value;
 
-#[derive(Debug, Object)]
+#[derive(PartialEq, Deserialize, Clone, Debug, Object)]
 struct BadRequestResult {
     error_code: i32,
     message: String,
@@ -34,6 +35,9 @@ enum MyResponse {
     /// C
     #[oai(status = 400)]
     BadRequest(Json<BadRequestResult>),
+    /// yaml response
+    #[oai(status = 400)]
+    BadRequestYaml(Yaml<BadRequestResult>),
     Default(StatusCode, PlainText<String>),
 }
 
@@ -59,6 +63,15 @@ fn meta() {
                     headers: vec![]
                 },
                 MetaResponse {
+                    description: "yaml response",
+                    status: Some(400),
+                    content: vec![MetaMediaType {
+                        content_type: "application/yaml; charset=utf-8",
+                        schema: MetaSchemaRef::Reference("BadRequestResult".to_string())
+                    }],
+                    headers: vec![]
+                },
+                MetaResponse {
                     description: "",
                     status: None,
                     content: vec![MetaMediaType {
@@ -77,19 +90,28 @@ async fn into_response() {
     let resp = MyResponse::Ok.into_response();
     assert_eq!(resp.status(), StatusCode::OK);
 
-    let mut resp = MyResponse::BadRequest(Json(BadRequestResult {
+    let resp = BadRequestResult {
         error_code: 123,
         message: "abc".to_string(),
-    }))
-    .into_response();
+    };
+    let mut json_resp = MyResponse::BadRequest(Json(resp.clone())).into_response();
+    let mut yaml_resp = MyResponse::BadRequestYaml(Yaml(resp.clone())).into_response();
     assert_eq!(
-        serde_json::from_slice::<Value>(&resp.take_body().into_bytes().await.unwrap()).unwrap(),
+        serde_json::from_slice::<Value>(&json_resp.take_body().into_bytes().await.unwrap())
+            .unwrap(),
         serde_json::json!({
             "error_code": 123,
             "message": "abc",
         })
     );
-    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(
+        serde_yaml::from_slice::<BadRequestResult>(
+            &yaml_resp.take_body().into_bytes().await.unwrap()
+        )
+        .unwrap(),
+        resp.clone()
+    );
+    assert_eq!(json_resp.status(), StatusCode::BAD_REQUEST);
 
     let mut resp = MyResponse::Default(StatusCode::BAD_GATEWAY, PlainText("abcdef".to_string()))
         .into_response();

--- a/poem/src/test/request_builder.rs
+++ b/poem/src/test/request_builder.rs
@@ -125,7 +125,7 @@ impl<'a, E> TestRequestBuilder<'a, E> {
     #[must_use]
     pub fn body_yaml(self, body: &impl Serialize) -> Self {
         self.content_type("application/yaml")
-            .body(serde_yaml::to_string(&body).expect("valid json"))
+            .body(serde_yaml::to_string(&body).expect("valid yaml"))
     }
 
     /// Sets the XML body for this request with `application/xml` content


### PR DESCRIPTION
- add `ParseFromYAML` & `ParseFromXML` implements for  derive macro `Object`
- fix implement errors in `ParsePayload` for and & yaml