### PR TITLE
fix(openapi): increase recursion limit

### DIFF
--- a/poem-openapi/src/lib.rs
+++ b/poem-openapi/src/lib.rs
@@ -113,6 +113,7 @@
 #![deny(private_in_public, unreachable_pub)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_docs)]
+#![recursion_limit = "512"]
 
 /// Macros to help with building custom payload types.
 #[macro_use]


### PR DESCRIPTION
`poem-openapi` it started  to fail under `cargo-tarpaulin` with `recursion limit`.

Example of failed CI job could be found in `poem` itself: https://github.com/poem-web/poem/actions/runs/4120444302/jobs/7115175776