### PR TITLE
Fix #500: Webpki roots

### DIFF
--- a/poem/Cargo.toml
+++ b/poem/Cargo.toml
@@ -48,7 +48,10 @@ i18n = [
     "unic-langid",
     "intl-memoizer",
 ]
-acme = [
+acme = ["acme-native-roots"]
+acme-native-roots = ["acme-base", "hyper-rustls/native-tokio"]
+acme-webpki-roots = ["acme-base", "hyper-rustls/webpki-tokio"]
+acme-base = [
     "server",
     "hyper/client",
     "rustls",
@@ -143,7 +146,12 @@ fluent-syntax = { version = "0.11.0", optional = true }
 unic-langid = { version = "0.9.0", optional = true, features = ["macros"] }
 intl-memoizer = { version = "0.5.1", optional = true }
 ring = { version = "0.16.20", optional = true }
-hyper-rustls = { version = "0.23.0", optional = true }
+hyper-rustls = { version = "0.23.0", optional = true, default-features = false, features = [
+    "http1",
+    "http2",
+    "tls12",
+    "logging",
+] }
 rcgen = { version = "0.10.0", optional = true }
 x509-parser = { version = "0.14.0", optional = true }
 tokio-metrics = { version = "0.1.0", optional = true }

--- a/poem/README.md
+++ b/poem/README.md
@@ -72,6 +72,7 @@ which are disabled by default:
 | eyre06        | Integrate with version 0.6.x of the [`eyre`](https://crates.io/crates/eyre) crate.        |
 | i18n          | Support for internationalization                                                          |
 | acme          | Support for ACME(Automatic Certificate Management Environment)                            |
+| acme-webpki-roots | Support for ACME using webpki TLS roots rather than native TLS roots                  |
 | tokio-metrics | Integrate with [`tokio-metrics`](https://crates.io/crates/tokio-metrics) crate.           |
 | embed         | Integrate with [`rust-embed`](https://crates.io/crates/rust-embed) crate.                 |
 | xml           | Integrate with [`quick-xml`](https://crates.io/crates/quick-xml) crate.                   |

--- a/poem/src/listener/acme/client.rs
+++ b/poem/src/listener/acme/client.rs
@@ -35,13 +35,13 @@ impl AcmeClient {
         key_pair: Arc<KeyPair>,
         contacts: Vec<String>,
     ) -> IoResult<Self> {
-        let client = Client::builder().build(
-            HttpsConnectorBuilder::new()
-                .with_native_roots()
-                .https_or_http()
-                .enable_http1()
-                .build(),
-        );
+        let client_builder = HttpsConnectorBuilder::new();
+        #[cfg(feature = "acme-native")]
+        let client_builder1 = client_builder.with_native_roots();
+        #[cfg(feature = "acme-webpki")]
+        let client_builder1 = client_builder.with_webpki_roots();
+        let client =
+            Client::builder().build(client_builder1.https_or_http().enable_http1().build());
         let directory = get_directory(&client, directory_url).await?;
         Ok(Self {
             client,

--- a/poem/src/listener/acme/client.rs
+++ b/poem/src/listener/acme/client.rs
@@ -36,9 +36,9 @@ impl AcmeClient {
         contacts: Vec<String>,
     ) -> IoResult<Self> {
         let client_builder = HttpsConnectorBuilder::new();
-        #[cfg(feature = "acme-native")]
+        #[cfg(feature = "acme-native-roots")]
         let client_builder1 = client_builder.with_native_roots();
-        #[cfg(feature = "acme-webpki")]
+        #[cfg(feature = "acme-webpki-roots")]
         let client_builder1 = client_builder.with_webpki_roots();
         let client =
             Client::builder().build(client_builder1.https_or_http().enable_http1().build());

--- a/poem/src/listener/mod.rs
+++ b/poem/src/listener/mod.rs
@@ -1,7 +1,7 @@
 //! Commonly used listeners.
 
-#[cfg(feature = "acme")]
-#[cfg_attr(docsrs, doc(cfg(feature = "acme")))]
+#[cfg(feature = "acme-base")]
+#[cfg_attr(docsrs, doc(cfg(feature = "acme-base")))]
 pub mod acme;
 mod combined;
 #[cfg(any(feature = "native-tls", feature = "rustls", feature = "openssl-tls"))]
@@ -29,7 +29,7 @@ use futures_util::{future::BoxFuture, FutureExt, TryFutureExt};
 use http::uri::Scheme;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf, Result as IoResult};
 
-#[cfg(feature = "acme")]
+#[cfg(feature = "acme-base")]
 use self::acme::{AutoCert, AutoCertListener};
 #[cfg(any(feature = "native-tls", feature = "rustls", feature = "openssl-tls"))]
 pub use self::handshake_stream::HandshakeStream;
@@ -213,8 +213,8 @@ pub trait Listener: Send {
     ///         .unwrap(),
     /// );
     /// ```
-    #[cfg(feature = "acme")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "acme")))]
+    #[cfg(feature = "acme-base")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "acme-base")))]
     #[must_use]
     fn acme(self, auto_cert: AutoCert) -> AutoCertListener<Self>
     where


### PR DESCRIPTION
This works to resolve CA issues in static binaries.

I added two new features:
- `acme-native-roots` which `acme` aliases for backwards compatibility.  I left `acme` in the documentation though, maybe I should replace that with `acme-native-roots`?
- `acme-webpki-roots` which selects webpki roots

I think this is similar to what other libraries do.  I thought this was clear and would provide a path for doing manual roots too in the future.  However, if you don't select either feature, there will be a compile error when building the AcmeClient.

An alternative is to have `acme-webpki-roots` be a toggle, where if it's missing native roots are used and if it's enabled native roots are disabled (and webpki roots are enabled).  This restricts it to exactly two modes however.