### PR TITLE
Add From<HashMap> implementation for I18NArgs

### DIFF
--- a/examples/poem/i18n/src/main.rs
+++ b/examples/poem/i18n/src/main.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use poem::{
     get, handler,
     i18n::{I18NResources, Locale},
@@ -15,9 +16,19 @@ fn index(locale: Locale) -> String {
 }
 
 #[handler]
-fn welcome(locale: Locale, Path(name): Path<String>) -> String {
+fn welcome_tuple(locale: Locale, Path(name): Path<String>) -> String {
     locale
         .text_with_args("welcome", (("name", name),))
+        .unwrap_or_else(|_| "error".to_string())
+}
+
+#[handler]
+fn welcome_hashmap(locale: Locale, Path(name): Path<String>) -> String {
+    let mut args = HashMap::new();
+    args.insert("name", name);
+
+    locale
+        .text_with_args("welcome", args)
         .unwrap_or_else(|_| "error".to_string())
 }
 
@@ -35,7 +46,8 @@ async fn main() -> Result<(), std::io::Error> {
 
     let app = Route::new()
         .at("/", get(index))
-        .at("/welcome/:name", get(welcome))
+        .at("/welcome_tuple/:name", get(welcome_tuple))
+        .at("/welcome_hashmap/:name", get(welcome_hashmap))
         .with(Tracing)
         .data(resources);
     Server::new(TcpListener::bind("127.0.0.1:3000"))

--- a/poem/src/i18n/args.rs
+++ b/poem/src/i18n/args.rs
@@ -1,4 +1,4 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, collections::HashMap};
 
 use fluent::{FluentArgs, FluentValue};
 
@@ -16,6 +16,20 @@ impl<'a> I18NArgs<'a> {
     {
         self.0.set(key, value);
         self
+    }
+}
+
+impl<'a, K, V> From<HashMap<K, V>> for I18NArgs<'a> 
+where
+K: Into<Cow<'a, str>>,
+V: Into<FluentValue<'a>>,
+{
+    fn from(map: HashMap<K, V>) -> Self {
+        let mut args = FluentArgs::new();
+        for (key, value) in map {
+            args.set(key, value);
+        }
+        Self(args)
     }
 }
 


### PR DESCRIPTION
I think the tuple way of mapping I18NArgs is very *poor*. For instance, when you don't know the amount of args, you must **handle each amounts**. So I implemented From\<HashMap>.

My personal use case is making a filter `translate` for tera templating:
```jsx
<h1>{{ "hello" | translate(name=name) }}</h1>
```

```rust
fn filter(&self, id: &Value, args: &HashMap<String, Value>) -> Result<Value> {
    self.locale
        .text_with_args(id.as_str().unwrap(), args)
        .map(|str| Value::String(str))
        .map_err(|err| Error::msg(err))
}
```