### PR TITLE
Public path pattern

### DIFF
--- a/poem/src/lib.rs
+++ b/poem/src/lib.rs
@@ -302,8 +302,8 @@ pub use poem_derive::handler;
 pub use request::{OnUpgrade, Request, RequestBuilder, RequestParts, Upgraded};
 pub use response::{Response, ResponseBuilder, ResponseParts};
 pub use route::{
-    connect, delete, get, head, options, patch, post, put, trace, Route, RouteDomain, RouteMethod,
-    RouteScheme,
+    connect, delete, get, head, options, patch, post, put, trace, PathPattern, Route, RouteDomain,
+    RouteMethod, RouteScheme,
 };
 #[cfg(feature = "server")]
 pub use server::Server;

--- a/poem/src/route/mod.rs
+++ b/poem/src/route/mod.rs
@@ -7,7 +7,6 @@ mod router_method;
 mod router_scheme;
 
 pub(crate) use internal::radix_tree::PathParams;
-#[allow(unreachable_pub)]
 pub use router::{PathPattern, Route};
 #[allow(unreachable_pub)]
 pub use router_domain::RouteDomain;

--- a/poem/src/route/router.rs
+++ b/poem/src/route/router.rs
@@ -306,7 +306,7 @@ impl Route {
     }
 }
 
-/// Container that can be used to obtain to obtain path pattern from the request.
+/// Container that can be used to obtain path pattern from the request.
 #[derive(Debug, Clone)]
 pub struct PathPattern(pub Arc<str>);
 

--- a/poem/src/route/router.rs
+++ b/poem/src/route/router.rs
@@ -306,8 +306,8 @@ impl Route {
     }
 }
 
+/// Container that can be used to obtain to obtain path pattern from the request.
 #[derive(Debug, Clone)]
-#[allow(unreachable_pub)]
 pub struct PathPattern(pub Arc<str>);
 
 #[async_trait::async_trait]


### PR DESCRIPTION
Right now `PathPattern` struct is not accessible. This PR makes it reachable.

Private `PathPattern` prevents users from writing their middleware that wants to rely on path patterns. Currently existing `OpenTelemetryMetrics` middleware is really a no-go for some, because of the enormous cardinality (HTTP_URL is to blame).