### PR TITLE
Allow not falling back to index file in StaticFilesEndpoint

### DIFF
--- a/poem/src/endpoint/static_files.rs
+++ b/poem/src/endpoint/static_files.rs
@@ -99,7 +99,7 @@ impl StaticFilesEndpoint {
             path: path.into(),
             show_files_listing: false,
             index_file: None,
-            fallback_to_index: true,
+            fallback_to_index: false,
             prefer_utf8: true,
             redirect_to_slash: false,
         }


### PR DESCRIPTION
The default for this option was true and could not be changed.