### PR TITLE
fix: alive connections counter for graceful shutdown

### DIFF
--- a/poem/src/server.rs
+++ b/poem/src/server.rs
@@ -130,7 +130,7 @@ where
                 },
                 res = acceptor.accept() => {
                     if let Ok((socket, local_addr, remote_addr, scheme)) = res {
-                        alive_connections.fetch_add(1, Ordering::SeqCst);
+                        alive_connections.fetch_add(1, Ordering::Release);
 
                         let ep = ep.clone();
                         let alive_connections = alive_connections.clone();
@@ -147,7 +147,7 @@ where
                                 serve_connection(socket, local_addr, remote_addr, scheme, ep).await;
                             }
 
-                            if alive_connections.fetch_sub(1, Ordering::SeqCst) == 1 {
+                            if alive_connections.fetch_sub(1, Ordering::Acquire) == 1 {
                                 notify.notify_one();
                             }
                         });
@@ -157,7 +157,7 @@ where
         }
 
         drop(acceptor);
-        if alive_connections.load(Ordering::SeqCst) > 0 {
+        if alive_connections.load(Ordering::Acquire) > 0 {
             tracing::info!(name = name, "wait for all connections to close.");
             notify.notified().await;
         }

--- a/poem/src/server.rs
+++ b/poem/src/server.rs
@@ -130,14 +130,14 @@ where
                 },
                 res = acceptor.accept() => {
                     if let Ok((socket, local_addr, remote_addr, scheme)) = res {
+                        alive_connections.fetch_add(1, Ordering::SeqCst);
+
                         let ep = ep.clone();
                         let alive_connections = alive_connections.clone();
                         let notify = notify.clone();
                         let timeout_notify = timeout_notify.clone();
 
                         tokio::spawn(async move {
-                            alive_connections.fetch_add(1, Ordering::SeqCst);
-
                             if timeout.is_some() {
                                 tokio::select! {
                                     _ = serve_connection(socket, local_addr, remote_addr, scheme, ep) => {}


### PR DESCRIPTION
It's currently looks a bit fragile:
It's possible to spawn new future, but parallel task will finish before spawned task is polled. 
So this check will notify waiter & stop server:
```rs
if alive_connections.fetch_sub(1, Ordering::SeqCst) == 1 {
    notify.notify_one();
}
```

It's hard to test, however sometimes we're encountering `connection reset` errors on client end, while server side almost immediately logged correct graceful shutdown & server stopped (we use large enough timeout, so it's not the case)

I believe it's more reliable & safe to increase counter before spawning the task of serving.