### PR TITLE
feat: upsert default_headers to dynamically change while testing

### DIFF
--- a/poem/src/test/client.rs
+++ b/poem/src/test/client.rs
@@ -71,7 +71,7 @@ impl<E: Endpoint> TestClient<E> {
         self
     }
 
-    /// Upserts the default header for each requests.
+    /// Upsert on default_headers for the current client.
     ///
     /// # Examples
     ///

--- a/poem/src/test/client.rs
+++ b/poem/src/test/client.rs
@@ -71,6 +71,53 @@ impl<E: Endpoint> TestClient<E> {
         self
     }
 
+    /// Upserts the default header for each requests.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use poem::{handler, http::HeaderMap, test::TestClient, Route};
+    ///
+    /// #[handler]
+    /// fn index(headers: &HeaderMap) -> String {
+    ///     headers
+    ///         .get("X-Custom-Header")
+    ///         .and_then(|value| value.to_str().ok())
+    ///         .unwrap_or_default()
+    ///         .to_string()
+    /// }
+    ///
+    /// let app = Route::new().at("/", index);
+    /// let cli = TestClient::new(app).default_header("X-Custom-Header", "test");
+    ///
+    /// # tokio::runtime::Runtime::new().unwrap().block_on(async {
+    /// let resp = cli.get("/").send().await;
+    /// resp.assert_status_is_ok();
+    /// resp.assert_text("test").await;
+    /// # });
+    ///
+    /// cli.upsert_default_header("X-Custom-Header", "updated");
+    ///
+    /// # tokio::runtime::Runtime::new().unwrap().block_on(async {
+    /// let resp = cli.get("/").send().await;
+    /// resp.assert_status_is_ok();
+    /// resp.assert_text("updated").await;
+    /// # });
+    /// ```
+    #[must_use]
+    pub fn upsert_default_header<K, V>(&mut self, key: K, value: V)
+    where
+        K: TryInto<HeaderName>,
+        V: TryInto<HeaderValue>,
+    {
+        let key = key.try_into().map_err(|_| ()).expect("valid header name");
+        let value = value
+            .try_into()
+            .map_err(|_| ())
+            .expect("valid header value");
+        self.default_headers.insert(key, value);
+    }
+
     /// Sets the default content type for each requests.
     #[must_use]
     pub fn default_content_type(self, content_type: impl AsRef<str>) -> Self {


### PR DESCRIPTION
## Summary
This pull request adds a new function, upsert_default_header(), to the TestClient struct. This function allows users to update or insert a default header value for each request, making it easier to rotate the Authorization header with different access tokens during testing.

## Changes
Add upsert_default_header() function to TestClient struct
Include example usage of upsert_default_header() in comments

## Scenario
While testing endpoints with User Auth I want to be able to dynamically change the Auth Header to simulate different users with different roles/access tokens.

```rust
    pub async fn set_auth(&mut self, user_id: i32, auth_role: AuthRole) {
        let (access_token, _) =
            AuthController::create_login_creds(&self.database, &self.secret, user_id, auth_role)
                .await
                .unwrap();

        self.test_client
            .upsert_default_header("Authorization", format!("Bearer {}", access_token));
    }
```

Please review the changes and let me know if you have any feedback or concerns.
