### PR TITLE
Trivial doc change to add `test` to the list of optional

### DIFF
--- a/poem/src/lib.rs
+++ b/poem/src/lib.rs
@@ -244,6 +244,7 @@
 //! |session           | Support for session    |
 //! |sse               | Support Server-Sent Events (SSE)       |
 //! |tempfile          | Support for [`tempfile`](https://crates.io/crates/tempfile) |
+//! |test              | Test utilities to test your endpoints. |
 //! |tower-compat      | Adapters for `tower::Layer` and `tower::Service`. |
 //! |websocket         | Support for WebSocket          |
 //! | anyhow        | Integrate with the [`anyhow`](https://crates.io/crates/anyhow) crate. |


### PR DESCRIPTION
Trivial doc change to add `test` to the list of optional crate features.

I found helpful examples for usage of `poem::test::TestClient` when making my first poem endpoint tests but it wasn't obvious I needed to enable the `test` feature since it wasn't included in this list.