### PR TITLE
fix: use compatible tracing version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ serde = { version = "1.0.130", features = ["derive"] }
 thiserror = "1.0.30"
 regex = "1.5.5"
 mime = "0.3.16"
-tracing = "0.1.29"
+tracing = "0.1.36"
 chrono = { version = "0.4.19", default-features = false }
 bytes = "1.1.0"
 futures-util = "0.3.17"


### PR DESCRIPTION
Seems like tracing changed public interface in https://github.com/tokio-rs/tracing/pull/2212

And poem is using the new interface already, so it fails with tracing <= 0.1.35.
```
    Checking poem v1.3.55 (https://github.com/poem-web/poem.git?branch=master#9941b489)
error[E0277]: the size for values of type `str` cannot be known at compilation time
    --> /Users/stepantubanov/.cargo/git/checkouts/poem-5d35782906f249bc/9941b48/poem/src/middleware/tracing_mw.rs:50:41
     |
50   |             span.record("path_pattern", path_pattern.0.as_ref());
     |                  ------                 ^^^^^^^^^^^^^^^^^^^^^^^ doesn't have a size known at compile-time
     |                  |
     |                  required by a bound introduced by this call
     |
     = help: the trait `Sized` is not implemented for `str`
note: required by a bound in `Span::record`
    --> /Users/stepantubanov/.cargo/registry/src/github.com-1ecc6299db9ec823/tracing-0.1.35/src/span.rs:1194:30
     |
1194 |     pub fn record<Q: ?Sized, V>(&self, field: &Q, value: &V) -> &Self
     |                              ^ required by this bound in `Span::record`

For more information about this error, try `rustc --explain E0277`.
error: could not compile `poem` due to previous error
```
