### PR TITLE
Remove unnecessary ok() from openapi-derive to make clippy happy

### DIFF
--- a/poem-openapi-derive/src/union.rs
+++ b/poem-openapi-derive/src/union.rs
@@ -105,18 +105,16 @@ pub(crate) fn generate(args: DeriveInput) -> GeneratorResult<TokenStream> {
                 } else if !args.one_of {
                     // any of
                     from_json.push(quote! {
-                        if let ::std::option::Option::Some(obj) = <#object_ty as #crate_name::types::ParseFromJSON>::parse_from_json(::std::option::Option::Some(::std::clone::Clone::clone(&value)))
-                            .map(Self::#item_ident)
-                            .ok() {
+                        if let ::std::result::Result::Ok(obj) = <#object_ty as #crate_name::types::ParseFromJSON>::parse_from_json(::std::option::Option::Some(::std::clone::Clone::clone(&value)))
+                            .map(Self::#item_ident) {
                             return ::std::result::Result::Ok(obj);
                         }
                     });
                 } else {
                     // one of
                     from_json.push(quote! {
-                        if let ::std::option::Option::Some(obj) = <#object_ty as #crate_name::types::ParseFromJSON>::parse_from_json(::std::option::Option::Some(::std::clone::Clone::clone(&value)))
-                            .map(Self::#item_ident)
-                            .ok() {
+                        if let ::std::result::Result::Ok(obj) = <#object_ty as #crate_name::types::ParseFromJSON>::parse_from_json(::std::option::Option::Some(::std::clone::Clone::clone(&value)))
+                            .map(Self::#item_ident) {
                             if res_obj.is_some() {
                                 return ::std::result::Result::Err(#crate_name::types::ParseError::expected_type(value));
                             }


### PR DESCRIPTION
Clippy with default settings complains about this in crates using the derive(Union).

```
> cargo clippy
[...]
warning: matching on `Some` with `ok()` is redundant
  --> path_to_my_api/mod.rs:55:10
   |
55 | #[derive(Union)]
   |          ^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#match_result_ok
   = note: `#[warn(clippy::match_result_ok)]` on by default
   = note: this warning originates in the derive macro `Union` (in Nightly builds, run with -Z macro-backtrace for more info)
```
