### PR TITLE
(Trivial) fix example curl commands in the README.md

### DIFF
--- a/poem-openapi/README.md
+++ b/poem-openapi/README.md
@@ -119,10 +119,10 @@ Open `http://localhost:3000/` in your browser, you will see the `Swagger UI` tha
 ```shell
 > cargo run --example hello_world
 
-> curl http://localhost:3000
+> curl http://localhost:3000/api/hello
 hello!
 
-> curl http://localhost:3000\?name\=sunli
+> curl http://localhost:3000/api/hello?name=sunli
 hello, sunli!        
 ```
 


### PR DESCRIPTION
The URLs were wrong.

Additionally, I couldn't get `cargo run --example hello_world` to work in either the root or the `poem-openapi/` directory, but maybe that's my version of `cargo` or something.