### PR TITLE
Update lib.rs to include openapi-explorer

### DIFF
--- a/poem-openapi/src/lib.rs
+++ b/poem-openapi/src/lib.rs
@@ -96,6 +96,7 @@
 //! | chrono     | Integrate with the [`chrono` crate](https://crates.io/crates/chrono) |
 //! | time  | Integrate with the [`time` crate](https://crates.io/crates/time). |
 //! | humantime  | Integrate with the [`humantime` crate](https://crates.io/crates/humantime) |
+//! | openapi-explorer | Add OpenAPI Explorer support |
 //! | swagger-ui | Add swagger UI support |
 //! | rapidoc    | Add RapiDoc UI support |
 //! | redoc      | Add Redoc UI support |


### PR DESCRIPTION
For some reason, this feature wasn't in the doc comment, but was in the README.md