### PR TITLE
fix: Lifetime in `UrlQuery::get`

### DIFF
--- a/poem-openapi/src/base.rs
+++ b/poem-openapi/src/base.rs
@@ -51,7 +51,7 @@ impl UrlQuery {
     }
 
     /// Returns the first value with the specified name.
-    pub fn get(&self, name: &str) -> Option<&String> {
+    pub fn get<'a>(&'a self, name: &'a str) -> Option<&String> {
         self.get_all(name).next()
     }
 }


### PR DESCRIPTION
Previously `cargo check` produced the following (also observed in [this](https://github.com/poem-web/poem/actions/runs/6000282399/job/16272035263) CI job):

```
error: lifetime may not live long enough
  --> poem-openapi/src/base.rs:55:9
   |
54 |     pub fn get(&self, name: &str) -> Option<&String> {
   |                -            - let's call the lifetime of this reference `'1`
   |                |
   |                let's call the lifetime of this reference `'2`
55 |         self.get_all(name).next()
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^ method was supposed to return data with lifetime `'2` but it is returning data with lifetime `'1`
   |
help: consider introducing a named lifetime parameter and update trait if needed
   |
54 |     pub fn get<'a>(&'a self, name: &'a str) -> Option<&String> {
   |               ++++  ++              ++

error: could not compile `poem-openapi` (lib) due to previous error
```
