### PR TITLE
fix: Json(Object) is not correct when f32 type in Object, when project use serde_json's "arbitrary_precision" feature.

### DIFF
--- a/poem-openapi/Cargo.toml
+++ b/poem-openapi/Cargo.toml
@@ -22,6 +22,7 @@ email = ["email_address"]
 hostname = ["hostname-validator"]
 static-files = ["poem/static-files"]
 websocket = ["poem/websocket"]
+arbitrary_precision = ["serde_json/arbitrary_precision"]
 
 [dependencies]
 poem-openapi-derive.workspace = true

--- a/poem-openapi/README.md
+++ b/poem-openapi/README.md
@@ -67,6 +67,7 @@ To avoid compiling unused dependencies, Poem gates certain features, some of whi
 | rust_decimal     | Integrate with the [`rust_decimal` crate](https://crates.io/crates/rust_decimal) |
 | static-files     | Support for static file response                                                 |
 | websocket        | Support for websocket                                                            |
+| arbitrary_precision | Support the `arbitrary_precision` feature inside [`serde_json` crate](https://crates.io/crates/serde_json) |
 
 ## Safety
 

--- a/poem-openapi/src/lib.rs
+++ b/poem-openapi/src/lib.rs
@@ -107,6 +107,7 @@
 //! | bson        | Integrate with the [`bson` crate](https://crates.io/crates/bson) |
 //! | rust_decimal | Integrate with the [`rust_decimal` crate](https://crates.io/crates/rust_decimal) |
 //! | static-files | Support for static file response |
+//! | arbitrary_precision | Support the `arbitrary_precision` feature inside [`serde_json` crate](https://crates.io/crates/serde_json) |
 
 #![doc(html_favicon_url = "https://raw.githubusercontent.com/poem-web/poem/master/favicon.ico")]
 #![doc(html_logo_url = "https://raw.githubusercontent.com/poem-web/poem/master/logo.png")]

--- a/poem-openapi/src/types/external/floats.rs
+++ b/poem-openapi/src/types/external/floats.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use poem::{http::HeaderValue, web::Field};
-use serde_json::{Number, Value};
+use serde_json::Value;
 
 use crate::{
     registry::{MetaSchema, MetaSchemaRef},
@@ -72,7 +72,7 @@ macro_rules! impl_type_for_floats {
 
         impl ToJSON for $ty {
             fn to_json(&self) -> Option<Value> {
-                Some(Value::Number(Number::from_f64(*self as f64).unwrap()))
+                Some(Value::from(*self))
             }
         }
 


### PR DESCRIPTION
cargo.toml：
```
...
serde_json = { version = "1.0.104", features = ["arbitrary_precision"] }
```
test code：
```
use poem::{listener::TcpListener, Route, Server};
use poem::Result;
use poem_openapi::{payload::Json, ApiResponse, OpenApi, OpenApiService};

struct Api;


#[derive(ApiResponse)]
enum TestResponse {
    #[oai(status = 200)]
    Ok(Json<Vec<f32>>),
}

#[OpenApi]
impl Api {
    #[oai(path = "/hello", method = "get")]
    async fn index(&self) -> Result<TestResponse> {
        let test_arr = vec![32.1, 32.2];
        Ok(TestResponse::Ok(Json(test_arr)))
    }
}

#[tokio::main]
async fn main() -> Result<(), std::io::Error> {
    if std::env::var_os("RUST_LOG").is_none() {
        std::env::set_var("RUST_LOG", "poem=debug");
    }
    tracing_subscriber::fmt::init();

    let api_service =
        OpenApiService::new(Api, "Hello World", "1.0").server("http://localhost:3000/api");
    let ui = api_service.swagger_ui();

    Server::new(TcpListener::bind("127.0.0.1:3000"))
        .run(Route::new().nest("/api", api_service).nest("/", ui))
        .await
}
```
I want got:
```
[
  32.1,
  32.2
]
```
But I got response:
```
[
  32.099998474121094,
  32.20000076293945
]
```

the commit is fixed the problem.