### PR TITLE
Allow using empty path in openapi

### DIFF
--- a/poem-openapi-derive/src/utils.rs
+++ b/poem-openapi-derive/src/utils.rs
@@ -114,7 +114,10 @@ pub(crate) fn convert_oai_path(path: &SpannedValue<String>) -> Result<(String, S
         return Ok((String::new(), String::new()));
     }
     if !path.starts_with('/') {
-        return Err(Error::new(path.span(), "The path must start with '/' or be empty."));
+        return Err(Error::new(
+            path.span(),
+            "The path must start with '/' or be empty.",
+        ));
     }
 
     let mut oai_path = String::new();

--- a/poem-openapi-derive/src/utils.rs
+++ b/poem-openapi-derive/src/utils.rs
@@ -114,7 +114,7 @@ pub(crate) fn convert_oai_path(path: &SpannedValue<String>) -> Result<(String, S
         return Ok((String::new(), String::new()));
     }
     if !path.starts_with('/') {
-        return Err(Error::new(path.span(), "The path must start with '/'."));
+        return Err(Error::new(path.span(), "The path must start with '/' or be empty."));
     }
 
     let mut oai_path = String::new();

--- a/poem-openapi-derive/src/utils.rs
+++ b/poem-openapi-derive/src/utils.rs
@@ -110,6 +110,9 @@ pub(crate) fn parse_oai_attrs<T: FromMeta>(attrs: &[Attribute]) -> GeneratorResu
 }
 
 pub(crate) fn convert_oai_path(path: &SpannedValue<String>) -> Result<(String, String)> {
+    if path.is_empty() {
+        return Ok((String::new(), String::new()));
+    }
     if !path.starts_with('/') {
         return Err(Error::new(path.span(), "The path must start with '/'."));
     }

--- a/poem-openapi/tests/api.rs
+++ b/poem-openapi/tests/api.rs
@@ -906,3 +906,34 @@ async fn issue_489() {
         .await
         .assert_status(StatusCode::METHOD_NOT_ALLOWED);
 }
+
+#[tokio::test]
+/// should allow path be an empty string
+async fn empty_path() {
+    struct Api;
+
+    #[OpenApi(prefix_path = "/empty_path")]
+    impl Api {
+        #[oai(path = "", method = "get")]
+        async fn get_empty_path(&self) -> PlainText<String> {
+            PlainText(String::from("empty"))
+        }
+        #[oai(path = "/", method = "get")]
+        async fn get_empty_path_slash(&self) -> PlainText<String> {
+            PlainText(String::from("slash"))
+        }
+    }
+
+    let ep = OpenApiService::new(Api, "test", "1.0");
+    let cli = TestClient::new(ep);
+    cli.get("/empty_path")
+        .send()
+        .await
+        .assert_text("empty")
+        .await;
+    cli.get("/empty_path/")
+        .send()
+        .await
+        .assert_text("slash")
+        .await;
+}


### PR DESCRIPTION
This pr is to slove the issue https://github.com/poem-web/poem/issues/645
May us allow the value of `path` parameter in `oai` macro to be empty since `/somepath` and  `/somepath/` are considered different?