### PR TITLE
Support for custom hash functions for HashMap

### DIFF
--- a/poem-openapi/src/types/external/hashmap.rs
+++ b/poem-openapi/src/types/external/hashmap.rs
@@ -1,4 +1,5 @@
 use std::{borrow::Cow, collections::HashMap, fmt::Display, hash::Hash, str::FromStr};
+use std::hash::BuildHasher;
 
 use serde_json::Value;
 
@@ -7,10 +8,11 @@ use crate::{
     types::{ParseError, ParseFromJSON, ParseResult, ToJSON, Type},
 };
 
-impl<K, V> Type for HashMap<K, V>
+impl<K, V, R> Type for HashMap<K, V, R>
 where
     K: ToString + FromStr + Eq + Hash + Sync + Send,
     V: Type,
+    R: Sync + Send,
 {
     const IS_REQUIRED: bool = true;
 
@@ -48,16 +50,17 @@ where
     }
 }
 
-impl<K, V> ParseFromJSON for HashMap<K, V>
+impl<K, V, R> ParseFromJSON for HashMap<K, V, R>
 where
     K: ToString + FromStr + Eq + Hash + Sync + Send,
     K::Err: Display,
     V: ParseFromJSON,
+    R: Sync + Send + Default + BuildHasher,
 {
     fn parse_from_json(value: Option<Value>) -> ParseResult<Self> {
         let value = value.unwrap_or_default();
         if let Value::Object(value) = value {
-            let mut obj = HashMap::new();
+            let mut obj = HashMap::with_hasher(R::default());
             for (key, value) in value {
                 let key = key
                     .parse()
@@ -72,10 +75,11 @@ where
     }
 }
 
-impl<K, V> ToJSON for HashMap<K, V>
+impl<K, V, R> ToJSON for HashMap<K, V, R>
 where
     K: ToString + FromStr + Eq + Hash + Sync + Send,
     V: ToJSON,
+    R: Sync + Send,
 {
     fn to_json(&self) -> Option<Value> {
         let mut map = serde_json::Map::new();

--- a/poem-openapi/src/types/external/hashmap.rs
+++ b/poem-openapi/src/types/external/hashmap.rs
@@ -1,5 +1,10 @@
-use std::{borrow::Cow, collections::HashMap, fmt::Display, hash::Hash, str::FromStr};
-use std::hash::BuildHasher;
+use std::{
+    borrow::Cow,
+    collections::HashMap,
+    fmt::Display,
+    hash::{BuildHasher, Hash},
+    str::FromStr,
+};
 
 use serde_json::Value;
 

--- a/poem-openapi/src/validation/max_properties.rs
+++ b/poem-openapi/src/validation/max_properties.rs
@@ -20,9 +20,9 @@ impl MaxProperties {
     }
 }
 
-impl<K, V> Validator<HashMap<K, V>> for MaxProperties {
+impl<K, V, R> Validator<HashMap<K, V, R>> for MaxProperties {
     #[inline]
-    fn check(&self, value: &HashMap<K, V>) -> bool {
+    fn check(&self, value: &HashMap<K, V, R>) -> bool {
         value.len() <= self.len
     }
 }

--- a/poem-openapi/src/validation/min_properties.rs
+++ b/poem-openapi/src/validation/min_properties.rs
@@ -20,9 +20,9 @@ impl MinProperties {
     }
 }
 
-impl<K, V> Validator<HashMap<K, V>> for MinProperties {
+impl<K, V, R> Validator<HashMap<K, V, R>> for MinProperties {
     #[inline]
-    fn check(&self, value: &HashMap<K, V>) -> bool {
+    fn check(&self, value: &HashMap<K, V, R>) -> bool {
         value.len() >= self.len
     }
 }

--- a/poem/src/i18n/args.rs
+++ b/poem/src/i18n/args.rs
@@ -19,12 +19,12 @@ impl<'a> I18NArgs<'a> {
     }
 }
 
-impl<'a, K, V> From<HashMap<K, V>> for I18NArgs<'a>
+impl<'a, K, V, R> From<HashMap<K, V, R>> for I18NArgs<'a>
 where
     K: Into<Cow<'a, str>>,
     V: Into<FluentValue<'a>>,
 {
-    fn from(map: HashMap<K, V>) -> Self {
+    fn from(map: HashMap<K, V, R>) -> Self {
         let mut args = FluentArgs::new();
         for (key, value) in map {
             args.set(key, value);


### PR DESCRIPTION
In this pull request, I added a generic parameter to all HashMap traits to support the custom Hash function. In my case, I wanted to add support for `ahash`.