### PR TITLE
count string length correctly in OpenAPI validators

### DIFF
--- a/poem-openapi/src/validation/max_length.rs
+++ b/poem-openapi/src/validation/max_length.rs
@@ -21,7 +21,7 @@ impl MaxLength {
 impl<T: AsRef<str>> Validator<T> for MaxLength {
     #[inline]
     fn check(&self, value: &T) -> bool {
-        value.as_ref().len() <= self.len
+        value.as_ref().chars().nth(self.len).is_none()
     }
 }
 

--- a/poem-openapi/src/validation/min_length.rs
+++ b/poem-openapi/src/validation/min_length.rs
@@ -21,7 +21,7 @@ impl MinLength {
 impl<T: AsRef<str>> Validator<T> for MinLength {
     #[inline]
     fn check(&self, value: &T) -> bool {
-        value.as_ref().len() >= self.len
+        self.len == 0 || value.as_ref().chars().nth(self.len - 1).is_some()
     }
 }
 

--- a/poem-openapi/tests/validation.rs
+++ b/poem-openapi/tests/validation.rs
@@ -128,6 +128,18 @@ fn test_max_length() {
         }
     );
     assert_eq!(
+        A::parse_from_json(Some(json!({ "value": "abcde" }))).unwrap(),
+        A {
+            value: "abcde".to_string()
+        }
+    );
+    assert_eq!(
+        A::parse_from_json(Some(json!({ "value": "שלום!" }))).unwrap(),
+        A {
+            value: "שלום!".to_string()
+        }
+    );
+    assert_eq!(
         A::parse_from_json(Some(json!({ "value": "abcdef" })))
             .unwrap_err()
             .into_message(),
@@ -148,6 +160,12 @@ fn test_min_length() {
     }
 
     assert_eq!(
+        A::parse_from_json(Some(json!({ "value": "abcde" }))).unwrap(),
+        A {
+            value: "abcde".to_string()
+        }
+    );
+    assert_eq!(
         A::parse_from_json(Some(json!({ "value": "abcdef" }))).unwrap(),
         A {
             value: "abcdef".to_string()
@@ -155,6 +173,12 @@ fn test_min_length() {
     );
     assert_eq!(
         A::parse_from_json(Some(json!({ "value": "abcd" })))
+            .unwrap_err()
+            .into_message(),
+        "failed to parse \"A\": field `value` verification failed. minLength(5)"
+    );
+    assert_eq!(
+        A::parse_from_json(Some(json!({ "value": "שלום" })))
             .unwrap_err()
             .into_message(),
         "failed to parse \"A\": field `value` verification failed. minLength(5)"


### PR DESCRIPTION
Currently in the poem's OpenAPI module, derived **maxLength** and **minLength** validators use `str::len()` method, which counts UTF-8 bytes, not Unicode characters in string. While **JSON Schema** spec defines **maxLength** and **minLength** for number of characters.

This pull request fixes that, also adding extra couple unit tests to better cover edge cases.