### PR TITLE
Derived Type, ParseFromJSON and IntoJSON for prost_wkt_types Struct a…

### DIFF
--- a/poem-openapi/Cargo.toml
+++ b/poem-openapi/Cargo.toml
@@ -68,6 +68,7 @@ bson = { version = "2.0.0", optional = true }
 rust_decimal = { version = "1.22.0", optional = true }
 humantime = { version = "2.1.0", optional = true }
 ipnet = { version = "2.7.1", optional = true }
+prost-wkt-types = { version = "0.5.0", optional = true}
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/poem-openapi/src/types/external/mod.rs
+++ b/poem-openapi/src/types/external/mod.rs
@@ -28,3 +28,5 @@ mod url;
 #[cfg(feature = "uuid")]
 mod uuid;
 mod vec;
+#[cfg(feature = "prost-wkt-types")]
+mod prost_wkt_types;

--- a/poem-openapi/src/types/external/prost_wkt_types/mod.rs
+++ b/poem-openapi/src/types/external/prost_wkt_types/mod.rs
@@ -1,0 +1,2 @@
+mod r#struct;
+mod value;

--- a/poem-openapi/src/types/external/prost_wkt_types/struct.rs
+++ b/poem-openapi/src/types/external/prost_wkt_types/struct.rs
@@ -1,0 +1,111 @@
+use std::borrow::Cow;
+
+use prost_wkt_types::Value;
+
+use crate::registry::{MetaSchema, MetaSchemaRef};
+use crate::types::{ParseError, ParseFromJSON, ParseResult, ToJSON, Type};
+
+impl Type for prost_wkt_types::Struct {
+    const IS_REQUIRED: bool = true;
+
+    type RawValueType = Self;
+
+    type RawElementValueType = <Value as Type>::RawValueType;
+
+    fn name() -> Cow<'static, str> {
+        "Protobuf Struct".into()
+    }
+
+    fn schema_ref() -> MetaSchemaRef {
+        MetaSchemaRef::Inline(Box::new(MetaSchema {
+            additional_properties: Some(Box::new(Value::schema_ref())),
+            ..MetaSchema::new("object")
+        }))
+    }
+
+    fn as_raw_value(&self) -> Option<&Self::RawValueType> {
+        Some(self)
+    }
+
+    fn raw_element_iter<'a>(
+        &'a self,
+    ) -> Box<dyn Iterator<Item=&'a Self::RawElementValueType> + 'a> {
+        self.fields.raw_element_iter()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.fields.is_empty()
+    }
+}
+
+impl ParseFromJSON for prost_wkt_types::Struct {
+    fn parse_from_json(value: Option<serde_json::Value>) -> ParseResult<Self> {
+        let value = value.unwrap_or_default();
+        if let serde_json::Value::Object(_) = &value {
+            serde_json::from_value::<prost_wkt_types::Struct>(value).map_err(|e| ParseError::custom(e.to_string()))
+        } else {
+            Err(ParseError::expected_type(value))
+        }
+    }
+}
+
+impl ToJSON for prost_wkt_types::Struct {
+    fn to_json(&self) -> Option<serde_json::Value> {
+        serde_json::to_value(self).ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use prost_wkt_types::Value;
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn parse_from_parameters() {
+        let prost_struct = prost_wkt_types::Struct::parse_from_json(Some(json!(
+            {
+                "f1":10_f64,
+                "f2":"Hi",
+                "f3":true,
+                "f4":null,
+                "f5": {"fa": "Hello"},
+                "f6": [1,2,3]
+            }
+        ))).unwrap();
+
+        assert_eq!(
+            prost_struct.fields.get("f1").unwrap(),
+            &Value::number(10_f64)
+        );
+        assert_eq!(
+            prost_struct.fields.get("f2").unwrap(),
+            &Value::string("Hi".to_string())
+        );
+        assert_eq!(
+            prost_struct.fields.get("f3").unwrap(),
+            &Value::bool(true)
+        );
+        assert_eq!(
+            prost_struct.fields.get("f4").unwrap(),
+            &Value::null()
+        );
+        assert_eq!(
+            prost_struct.fields.get("f5").unwrap(),
+            &Value::pb_struct(
+                HashMap::from([("fa".into(), Value::string("Hello".into()))])
+            )
+        );
+        assert_eq!(
+            prost_struct.fields.get("f6").unwrap(),
+            &Value::pb_list(
+                vec![Value::number(1_f64),
+                     Value::number(2_f64),
+                     Value::number(3_f64)]
+            )
+        );
+    }
+}

--- a/poem-openapi/src/types/external/prost_wkt_types/value.rs
+++ b/poem-openapi/src/types/external/prost_wkt_types/value.rs
@@ -1,0 +1,131 @@
+use std::borrow::Cow;
+
+use prost_wkt_types::value::Kind;
+
+use crate::registry::{MetaSchema, MetaSchemaRef};
+use crate::types::{ParseError, ParseFromJSON, ParseResult, ToJSON, Type};
+
+impl Type for prost_wkt_types::Value {
+    const IS_REQUIRED: bool = true;
+
+    type RawValueType = prost_wkt_types::Value;
+
+    type RawElementValueType = prost_wkt_types::Value;
+
+    fn name() -> Cow<'static, str> {
+        "Protobuf Value".into()
+    }
+
+    fn schema_ref() -> MetaSchemaRef {
+        MetaSchemaRef::Inline(Box::new(MetaSchema::ANY))
+    }
+
+    fn as_raw_value(&self) -> Option<&Self::RawValueType> {
+        Some(self)
+    }
+
+    fn raw_element_iter<'a>(
+        &'a self,
+    ) -> Box<dyn Iterator<Item=&'a Self::RawElementValueType> + 'a> {
+        Box::new(self.as_raw_value().into_iter())
+    }
+    fn is_empty(&self) -> bool {
+        matches!(self.kind, Some(Kind::NullValue(_)) | None)
+    }
+}
+
+
+impl ParseFromJSON for prost_wkt_types::Value {
+    fn parse_from_json(value: Option<serde_json::Value>) -> ParseResult<Self> {
+        let value = value.unwrap_or_default();
+        serde_json::from_value(value).map_err(|e| ParseError::custom(e.to_string()))
+    }
+}
+
+impl ToJSON for prost_wkt_types::Value {
+    fn to_json(&self) -> Option<serde_json::Value> {
+        serde_json::to_value(self).ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use prost_wkt_types::Value;
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn parse_from_number() {
+        let value = Value::parse_from_json(Some(
+            json!(10_f64)
+        )).unwrap();
+        assert_eq!(
+            value,
+            Value::number(10_f64)
+        );
+    }
+
+    #[test]
+    fn parse_from_string() {
+        let value = Value::parse_from_json(Some(
+            json!("Hi")
+        )).unwrap();
+        assert_eq!(
+            value,
+            Value::string("Hi".into())
+        );
+    }
+
+    #[test]
+    fn parse_from_bool() {
+        let value = Value::parse_from_json(Some(
+            json!(true)
+        )).unwrap();
+        assert_eq!(
+            value,
+            Value::bool(true)
+        );
+    }
+
+    #[test]
+    fn parse_from_null() {
+        let value = Value::parse_from_json(Some(
+            json!(null)
+        )).unwrap();
+        assert_eq!(
+            value,
+            Value::null()
+        );
+    }
+
+    #[test]
+    fn parse_from_struct() {
+        let value = Value::parse_from_json(Some(
+            json!({"f1": "Hello"})
+        )).unwrap();
+        assert_eq!(
+            value,
+            Value::pb_struct(
+                HashMap::from([("f1".into(), Value::string("Hello".into()))])
+            )
+        );
+    }
+
+    #[test]
+    fn parse_from_list() {
+        let value = Value::parse_from_json(Some(
+            json!([1,2,3])
+        )).unwrap();
+        assert_eq!(
+            value,
+            Value::pb_list(
+                vec![Value::number(1_f64),
+                     Value::number(2_f64),
+                     Value::number(3_f64)]
+            )
+        );
+    }
+}


### PR DESCRIPTION
Added support for prost-wkt-types Struct and Value to be derived as ```poem_openapi::Object```. This makes it easier to forward a grpc message through a standard poem http endpoint.