### PR TITLE
feat: use ToString instead of Into<String> for Plaintext

### DIFF
--- a/poem-openapi/src/payload/plain_text.rs
+++ b/poem-openapi/src/payload/plain_text.rs
@@ -52,13 +52,13 @@ impl ParsePayload for PlainText<String> {
     }
 }
 
-impl<T: Into<String> + Send> IntoResponse for PlainText<T> {
+impl<T: ToString + Send> IntoResponse for PlainText<T> {
     fn into_response(self) -> Response {
-        self.0.into().into_response()
+        self.0.to_string().into_response()
     }
 }
 
-impl<T: Into<String> + Send> ApiResponse for PlainText<T> {
+impl<T: ToString + Send> ApiResponse for PlainText<T> {
     fn meta() -> MetaResponses {
         MetaResponses {
             responses: vec![MetaResponse {


### PR DESCRIPTION
At the moment `poem` uses `Into<String>` in a lot of places where `ToString` could be used instead.

`ToString` is a far more common trait, being implicit on things with `Display` implementations.
My use case is that I have things with `thiserror::Error` derived on them, and want to be able to Just Use Them in poem_openapi responses.

I can obviously just write out:
```rs
impl Into<String> for Type {
	fn into(&self) -> String {
		self.to_string()
	}
}
```

for all of my types, but this seems needlessly redundant.

## Impl

I've only done this for `Plaintext`. It's possible that this could also work for the `impl <T: Into<String> + Send IntoResponse for Html` blocks, but I did not test it.

## Breakage

This change could potentially break code in which users have `Into<String>` defined but not `Display` or anything that implies `ToString`. This is rather unlikely, though.