### PR TITLE
allow WebSocket casing for upgrade header

### DIFF
--- a/poem/src/web/websocket/extractor.rs
+++ b/poem/src/web/websocket/extractor.rs
@@ -28,8 +28,12 @@ pub struct WebSocket {
 
 impl WebSocket {
     async fn internal_from_request(req: &Request) -> Result<Self, WebSocketError> {
+        let is_valid_upgrade_header = req.headers().get(header::UPGRADE)
+            == Some(&HeaderValue::from_static("websocket"))
+            || req.headers().get(header::UPGRADE) == Some(&HeaderValue::from_static("WebSocket"));
+
         if req.method() != Method::GET
-            || req.headers().get(header::UPGRADE) != Some(&HeaderValue::from_static("websocket"))
+            || !is_valid_upgrade_header
             || req.headers().get(header::SEC_WEBSOCKET_VERSION)
                 != Some(&HeaderValue::from_static("13"))
         {


### PR DESCRIPTION
The RFC [allows the use of](https://datatracker.ietf.org/doc/html/rfc6455#section-11.2) `WebSocket` which some frameworks follow, e.g. [autobahn](https://github.com/crossbario/autobahn-python/issues/1489#issuecomment-861391942). 