### PR TITLE
impl `Type` for `std::time::Duration` instead of only `humantime::Duration`

### DIFF
--- a/poem-openapi/src/types/external/humantime_wrapper.rs
+++ b/poem-openapi/src/types/external/humantime_wrapper.rs
@@ -1,0 +1,78 @@
+use std::borrow::Cow;
+
+use humantime::Duration;
+use poem::{http::HeaderValue, web::Field};
+use serde_json::Value;
+
+use crate::{
+    registry::{MetaSchema, MetaSchemaRef},
+    types::{
+        ParseError, ParseFromJSON, ParseFromMultipartField, ParseFromParameter, ParseResult,
+        ToHeader, ToJSON, Type,
+    },
+};
+
+impl Type for Duration {
+    const IS_REQUIRED: bool = true;
+
+    type RawValueType = Self;
+
+    type RawElementValueType = Self;
+
+    fn name() -> Cow<'static, str> {
+        "string(duration)".into()
+    }
+
+    fn schema_ref() -> MetaSchemaRef {
+        MetaSchemaRef::Inline(Box::new(MetaSchema::new_with_format("string", "duration")))
+    }
+
+    fn as_raw_value(&self) -> Option<&Self::RawValueType> {
+        Some(self)
+    }
+
+    fn raw_element_iter<'a>(
+        &'a self,
+    ) -> Box<dyn Iterator<Item = &'a Self::RawElementValueType> + 'a> {
+        Box::new(self.as_raw_value().into_iter())
+    }
+}
+
+impl ParseFromJSON for Duration {
+    fn parse_from_json(value: Option<Value>) -> ParseResult<Self> {
+        let value = value.unwrap_or_default();
+        if let Value::String(value) = value {
+            Ok(value.parse()?)
+        } else {
+            Err(ParseError::expected_type(value))
+        }
+    }
+}
+
+impl ParseFromParameter for Duration {
+    fn parse_from_parameter(value: &str) -> ParseResult<Self> {
+        value.parse().map_err(ParseError::custom)
+    }
+}
+
+#[poem::async_trait]
+impl ParseFromMultipartField for Duration {
+    async fn parse_from_multipart(field: Option<Field>) -> ParseResult<Self> {
+        match field {
+            Some(field) => Ok(field.text().await?.parse()?),
+            None => Err(ParseError::expected_input()),
+        }
+    }
+}
+
+impl ToJSON for Duration {
+    fn to_json(&self) -> Option<Value> {
+        Some(Value::String(self.to_string()))
+    }
+}
+
+impl ToHeader for Duration {
+    fn to_header(&self) -> Option<HeaderValue> {
+        HeaderValue::from_str(&self.to_string()).ok()
+    }
+}

--- a/poem-openapi/src/types/external/mod.rs
+++ b/poem-openapi/src/types/external/mod.rs
@@ -16,6 +16,8 @@ mod hashmap;
 mod hashset;
 #[cfg(feature = "humantime")]
 mod humantime;
+#[cfg(feature = "humantime")]
+mod humantime_wrapper;
 mod integers;
 mod ip;
 mod optional;


### PR DESCRIPTION
# TLDR
1. You can't derive `serde::{Deserialize, Serialize}` together with `poem_openapi::Object` with the current implementation, but I expect that's what most people would want to do. If you want to derive `Object` for a struct, chances are that you will use it for an API request or response, so you will also need to derive serde, but at the moment that's not possible
2. `humantime` and `humantime_serde` themselves prefer using `std::time::Duration` instead of the wrapper type `humantime::Duration`, so it makes more sense to make poem work with it too

# Reasoning
Recently I wanted to make a struct that derived `serde::{Deserialize, Serialize}` as well as `poem_openapi::Object`. This struct had to have one `Duration` field which is parsed as human-readable strings, like `15s` or `5m`. Unfortunately that's where the problems began. 

## Attempt 1
```rust
#[derive(Debug, Object, Serialize, Deserialize)] // the trait bound `std::time::Duration: poem_openapi::types::Type` is not satisfied
struct MyStruct {
    #[serde(with = "humantime_serde")]
    field: std::time::Duration,
}
```
This example does not work because `Object` is impl'd for the wrapper type `humantime::Duration` instead of `std::time::Duration`.

## Attempt 2
```rust
#[derive(Debug, Object, Serialize, Deserialize)]
struct MyStruct {
    field: humantime::Duration,
}
```
This does not work because `Serialize` and `Deserialize` are not implemented for `humantime::Duration`. Adding `#[serde(with = "humantime_serde")]` above the struct's field does not help either because `humantime_serde` returns `std::time::Duration` using the `humantime` parsing functions. It does not operate on the wrapper struct.

# Solutions
As far as I know it wasn't possible to resolve this problem without some customizations. I came up with 3 possible solutions

## Solution 1
Create my own wrapper struct and impl several traits on it so I can derive `Object`.
```rust
#[derive(Debug, Deserialize, Serialize)]
struct MyDuration(#[serde(with = "humantime_serde")] std::time::Duration);

impl Type for MyDuration { ... }
impl ParseFromJSON for MyDuration { ... }
impl ToJSON for MyDuration { ... }

#[derive(Debug, Object, Serialize, Deserialize)]
struct MyStruct {
    field: MyDuration,
}
```
This solution is quite verbose and I don't like using unnecessary wrappers for std types.

## Solution 2
Use the `humantime::Duration` wrapper on my struct and tell serde how to parse it
```rust
mod myserde {
    use serde::{Deserialize, Deserializer, Serializer};

    pub fn deserialize<'a, D: Deserializer<'a>>(d: D) -> Result<humantime::Duration, D::Error> {
        let s = String::deserialize(d)?;
        let parsed = humantime::parse_duration(&s).map_err(serde::de::Error::custom)?;
        Ok(humantime::Duration::from(parsed))
    }

    pub fn serialize<S: Serializer>(d: &humantime::Duration, s: S) -> Result<S::Ok, S::Error> {
        s.serialize_str(&d.to_string())
    }
}

#[derive(Debug, Object, Serialize, Deserialize)]
struct MyStruct {
    #[serde(with = "myserde")]
    field: humantime::Duration,
}
```
This is less verbose, but I still don't like using wrappers on my struct cause they make it harder to interact with non-wrapped Durations. I was going to use this solution, until I came up with the next one.

## Solution 3
Edit `poem-openapi` to impl `Type` and the other traits on `std::time::Duration` instead of `humantime::Duration`. That's this very PR.

# Why I think solution 3 is best
- You can use the std Duration on your struct so it becomes easier to interact with non-wrapped Durations
- You can piggyback off of `humantime_serde` for `serde` integration
- It allows for more natural code. If you want to have a Duration on your struct, you use Rust's std::time::Duration without worrying about wrappers to satisfy poem or custom serialize, deserialize functions to satisfy serde. If you wanna parse it as human-readable strings with serde, you use `humantime_serde` which is what `humantime` itself recommends in its docs
- It's more consistent. By now you might have noticed a trend - `humantime`'s `parse_duration` and `format_duration` functions work with `std::time::Duration`, its other functions also work with std types, `humantime_serde` prefers the std types too. Everything humantime-related is nudging you towards using the std types as much as possible because they're more portable and easier to work with. Therefore `poem-openapi` should work with `std::time::Duration` instead of `humantime::Duration`.

Since this solution is still using `humantime` for the actual duration-parsing, we don't need to change much. The `humantime` dependency and feature flag remain unchanged. We only need to edit 5 lines (minus the imports).

With these changes in place, the example in `Attempt 1` becomes valid.

I know this is a breaking change, but I think it's worth it because it makes the `humantime` integration behave the way that most users would expect in my opinion. And it certainly makes it easier to use it together with serde on one struct.

Please review, @sunli829, and let me know if this is okay. I think this is for the best, although it wouldn't be difficult to keep both the old impl for `humantime::Duration` and this new impl in case some code relies on the current behavior.

# Update
A friend of mine pointed that it's probably *not* the smartest move to break the existing behavior in case anybody relies on it since it's not necessary to do so. So I will re-add the old implementation in a separate file called `humantime_wrapper.rs` which is also gated behind the `humantime` feature flag. Now with this PR the code examples in `Attempt 1` and `Solution 2` both become valid.