### PR TITLE
feat(openapi): added example value support for param/schema

### DIFF
--- a/poem-openapi-derive/src/api.rs
+++ b/poem-openapi-derive/src/api.rs
@@ -7,7 +7,7 @@ use syn::{
 };
 
 use crate::{
-    common_args::{APIMethod, CodeSample, DefaultValue, ExternalDocument, ExtraHeader},
+    common_args::{APIMethod, CodeSample, DefaultValue, ExampleValue, ExternalDocument, ExtraHeader},
     error::GeneratorResult,
     utils::{
         convert_oai_path, get_crate_name, get_description, get_summary_and_description,
@@ -67,6 +67,8 @@ struct APIOperationParam {
     deprecated: bool,
     #[darling(default)]
     default: Option<DefaultValue>,
+    #[darling(default)]
+    example: Option<ExampleValue>,
     #[darling(default)]
     validator: Option<Validators>,
     #[darling(default)]
@@ -306,6 +308,27 @@ fn generate_operation(
             None => quote!(::std::option::Option::None),
         };
 
+        // example value for parameter
+        let example_value = match &operation_param.example {
+            Some(ExampleValue::Default) => {
+                quote!(::std::option::Option::Some(<<#arg_ty as #crate_name::ApiExtractor>::ParamType as std::default::Default>::default))
+            }
+            Some(ExampleValue::Function(func_name)) => {
+                quote!(::std::option::Option::Some(#func_name))
+            }
+            None => quote!(::std::option::Option::None),
+        };
+
+        let param_meta_example = match &operation_param.example {
+            Some(ExampleValue::Default) => {
+                quote!(#crate_name::types::ToJSON::to_json(&<<#arg_ty as #crate_name::ApiExtractor>::ParamType as std::default::Default>::default()))
+            }
+            Some(ExampleValue::Function(func_name)) => {
+                quote!(#crate_name::types::ToJSON::to_json(&#func_name()))
+            }
+            None => quote!(::std::option::Option::None),
+        };
+
         // validator
         let validator = operation_param.validator.clone().unwrap_or_default();
         let param_checker = validator.create_param_checker(crate_name, &res_ty, &param_name)?.map(|stream| {
@@ -326,6 +349,7 @@ fn generate_operation(
             let mut param_opts = #crate_name::ExtractParamOptions {
                 name: #param_name,
                 default_value: #default_value,
+                example_value: #example_value,
                 explode: #explode,
             };
 
@@ -351,6 +375,7 @@ fn generate_operation(
                 let mut patch_schema = {
                     let mut schema = #crate_name::registry::MetaSchema::ANY;
                     schema.default = #param_meta_default;
+                    schema.example = #param_meta_example;
                     #validators_update_meta
                     schema
                 };

--- a/poem-openapi-derive/src/api.rs
+++ b/poem-openapi-derive/src/api.rs
@@ -7,7 +7,9 @@ use syn::{
 };
 
 use crate::{
-    common_args::{APIMethod, CodeSample, DefaultValue, ExampleValue, ExternalDocument, ExtraHeader},
+    common_args::{
+        APIMethod, CodeSample, DefaultValue, ExampleValue, ExternalDocument, ExtraHeader,
+    },
     error::GeneratorResult,
     utils::{
         convert_oai_path, get_crate_name, get_description, get_summary_and_description,

--- a/poem-openapi-derive/src/common_args.rs
+++ b/poem-openapi-derive/src/common_args.rs
@@ -171,6 +171,25 @@ impl FromMeta for DefaultValue {
     }
 }
 
+#[derive(Debug)]
+pub(crate) enum ExampleValue {
+    Default,
+    Function(Path),
+}
+
+impl FromMeta for ExampleValue {
+    fn from_word() -> darling::Result<Self> {
+        Ok(ExampleValue::Default)
+    }
+
+    fn from_value(value: &Lit) -> darling::Result<Self> {
+        match value {
+            Lit::Str(str) => Ok(ExampleValue::Function(syn::parse_str(&str.value())?)),
+            _ => Err(darling::Error::unexpected_lit_type(value).with_span(value)),
+        }
+    }
+}
+
 #[derive(FromMeta, Clone)]
 pub(crate) struct MaximumValidator {
     pub(crate) value: f64,

--- a/poem-openapi/src/base.rs
+++ b/poem-openapi/src/base.rs
@@ -65,6 +65,9 @@ pub struct ExtractParamOptions<T> {
     /// The default value of this parameter.
     pub default_value: Option<fn() -> T>,
 
+    /// The example value of this parameter.
+    pub example_value: Option<fn() -> T>,
+
     /// When this is `true`, parameter values of type array or object generate
     /// separate parameters for each value of the array or key-value pair of the
     /// map.
@@ -76,6 +79,7 @@ impl<T> Default for ExtractParamOptions<T> {
         Self {
             name: "",
             default_value: None,
+            example_value: None,
             explode: true,
         }
     }

--- a/poem-openapi/tests/operation_param.rs
+++ b/poem-openapi/tests/operation_param.rs
@@ -420,10 +420,8 @@ async fn example() {
         #[oai(path = "/", method = "get")]
         async fn test(
             &self,
-            #[oai(example = "example_value")]
-            a: Query<Option<i32>>,
-            #[oai(example)]
-            b: Query<i32>,
+            #[oai(example = "example_value")] a: Query<Option<i32>>,
+            #[oai(example)] b: Query<i32>,
         ) {
             todo!();
         }

--- a/poem-openapi/tests/operation_param.rs
+++ b/poem-openapi/tests/operation_param.rs
@@ -411,6 +411,54 @@ async fn default_opt() {
 }
 
 #[tokio::test]
+async fn example() {
+    struct Api;
+
+    #[OpenApi]
+    #[allow(unused_variables)]
+    impl Api {
+        #[oai(path = "/", method = "get")]
+        async fn test(
+            &self,
+            #[oai(example = "example_value")]
+            a: Query<Option<i32>>,
+            #[oai(example)]
+            b: Query<i32>,
+        ) {
+            todo!();
+        }
+    }
+
+    fn example_value() -> Option<i32> {
+        Some(88)
+    }
+
+    let meta: MetaApi = Api::meta().remove(0);
+    assert_eq!(
+        meta.paths[0].operations[0].params[0].in_type,
+        MetaParamIn::Query
+    );
+
+    assert_eq!(meta.paths[0].operations[0].params[0].name, "a");
+    assert_eq!(
+        meta.paths[0].operations[0].params[0]
+            .schema
+            .unwrap_inline()
+            .example,
+        Some(json!(88))
+    );
+
+    assert_eq!(meta.paths[0].operations[0].params[1].name, "b");
+    assert_eq!(
+        meta.paths[0].operations[0].params[1]
+            .schema
+            .unwrap_inline()
+            .example,
+        Some(json!(0))
+    );
+}
+
+#[tokio::test]
 async fn required_params() {
     struct Api;
 


### PR DESCRIPTION
## Example Code

![image](https://github.com/poem-web/poem/assets/81347541/d650029a-75b2-4a8c-8d5a-94edc1affb41)

```rs
struct Api;

fn hello_world() -> String { String::from("Hello World") }

#[OpenApi]
impl Api {
    #[oai(path = "/", method = "get")]
    async fn get(
        &self,
        #[oai(example = "hello_world")] name: Query<String>,
    ) -> PlainText(String) {
        PlainText(name.0)
    }
}
```