### PR TITLE
Add enum_items to discriminated union

### DIFF
--- a/poem-openapi-derive/src/union.rs
+++ b/poem-openapi-derive/src/union.rs
@@ -152,13 +152,14 @@ pub(crate) fn generate(args: DeriveInput) -> GeneratorResult<TokenStream> {
                                     properties: ::std::vec![
                                         (
                                             #discriminator_name,
-                                            #crate_name::registry::MetaSchemaRef::merge(
-                                                <::std::string::String as #crate_name::types::Type>::schema_ref(),
+                                            #crate_name::registry::MetaSchemaRef::Inline(::std::boxed::Box::new(
                                                 #crate_name::registry::MetaSchema {
+                                                    ty: "string",
+                                                    enum_items: ::std::vec![::std::convert::Into::into(#mapping_name)],
                                                     example: ::std::option::Option::Some(::std::convert::Into::into(#mapping_name)),
                                                     ..#crate_name::registry::MetaSchema::ANY
                                                 }
-                                            )
+                                            )),
                                         )
                                     ],
                                     ..#crate_name::registry::MetaSchema::new("object")
@@ -167,6 +168,7 @@ pub(crate) fn generate(args: DeriveInput) -> GeneratorResult<TokenStream> {
                             ],
                             ..#crate_name::registry::MetaSchema::ANY
                         };
+
                         registry.schemas.insert(#schema_name, schema);
                     });
 

--- a/poem-openapi/tests/union.rs
+++ b/poem-openapi/tests/union.rs
@@ -70,10 +70,12 @@ fn with_discriminator() {
                     required: vec!["type"],
                     properties: vec![(
                         "type",
-                        String::schema_ref().merge(MetaSchema {
+                        MetaSchemaRef::Inline(Box::new(MetaSchema {
+                            ty: "string",
                             example: Some("A".into()),
+                            enum_items: vec!["A".into()],
                             ..MetaSchema::ANY
-                        }),
+                        }))
                     )],
                     ..MetaSchema::new("object")
                 })),
@@ -92,10 +94,12 @@ fn with_discriminator() {
                     required: vec!["type"],
                     properties: vec![(
                         "type",
-                        String::schema_ref().merge(MetaSchema {
+                        MetaSchemaRef::Inline(Box::new(MetaSchema {
+                            ty: "string",
                             example: Some("B".into()),
+                            enum_items: vec!["B".into()],
                             ..MetaSchema::ANY
-                        })
+                        }))
                     )],
                     ..MetaSchema::new("object")
                 })),
@@ -202,10 +206,12 @@ fn with_discriminator_mapping() {
                     required: vec!["type"],
                     properties: vec![(
                         "type",
-                        String::schema_ref().merge(MetaSchema {
+                        MetaSchemaRef::Inline(Box::new(MetaSchema {
+                            ty: "string",
                             example: Some("c".into()),
+                            enum_items: vec!["c".into()],
                             ..MetaSchema::ANY
-                        }),
+                        }))
                     )],
                     ..MetaSchema::new("object")
                 })),
@@ -224,10 +230,12 @@ fn with_discriminator_mapping() {
                     required: vec!["type"],
                     properties: vec![(
                         "type",
-                        String::schema_ref().merge(MetaSchema {
+                        MetaSchemaRef::Inline(Box::new(MetaSchema {
+                            ty: "string",
                             example: Some("d".into()),
+                            enum_items: vec!["d".into()],
                             ..MetaSchema::ANY
-                        })
+                        }))
                     )],
                     ..MetaSchema::new("object")
                 })),


### PR DESCRIPTION
This specifies the discriminator property of the discriminated union as a string literal. As OpenApi doesn't support string literals its common practice to define a literal as an enum of one option. (reference: https://github.com/OAI/OpenAPI-Specification/issues/1313#issuecomment-366988466)

This helps with code generators as it generates a type-safe discriminated union. Following is a Typescript example.


With enum defined:
```ts
ex: 

type Animal =
   | { type: 'Dog', bark: string }
   | { type: 'Cat', name: string }
```

Without enum defined ("type" looses its literals):

```ts
ex: 

type Animal =
   | { type: string, bark: string }
   | { type: string, name: string }
```