### PR TITLE
Adding `serialize_with` and `deserialize_with` attributes to struct fields

### DIFF
--- a/poem-openapi-derive/src/object.rs
+++ b/poem-openapi-derive/src/object.rs
@@ -42,6 +42,10 @@ struct ObjectField {
     skip_serializing_if_is_empty: bool,
     #[darling(default)]
     skip_serializing_if: Option<Path>,
+    #[darling(default)]
+    serialize_with: Option<Path>,
+    #[darling(default)]
+    deserialize_with: Option<Path>,
 }
 
 #[derive(FromDeriveInput)]
@@ -194,15 +198,22 @@ pub(crate) fn generate(args: DeriveInput) -> GeneratorResult<TokenStream> {
                         };
                     });
                 }
-                None => deserialize_fields.push(quote! {
-                    #[allow(non_snake_case)]
-                    let #field_ident: #field_ty = {
-                        let value = #crate_name::types::ParseFromJSON::parse_from_json(obj.remove(#field_name))
-                            .map_err(#crate_name::types::ParseError::propagate)?;
-                        #validators_checker
-                        value
+                None => {
+                    let deserialize_function = match field.deserialize_with {
+                        Some(ref function) => quote! { #function },
+                        None => quote!{ #crate_name::types::ParseFromJSON::parse_from_json }
                     };
-                }),
+                    
+                    deserialize_fields.push(quote! {
+                        #[allow(non_snake_case)]
+                        let #field_ident: #field_ty = {
+                            let value = #deserialize_function(obj.remove(#field_name))
+                                .map_err(#crate_name::types::ParseError::propagate)?;
+                            #validators_checker
+                            value
+                        };
+                    })
+                },
             }
         } else {
             if args.deny_unknown_fields {
@@ -239,9 +250,14 @@ pub(crate) fn generate(args: DeriveInput) -> GeneratorResult<TokenStream> {
                     quote!(true)
                 };
 
+                let serialize_function = match field.serialize_with {
+                    Some(ref function) => quote!{ #function },
+                    None => quote!{ #crate_name::types::ToJSON::to_json },
+                };
+
                 serialize_fields.push(quote! {
                     if #check_is_none && #check_is_empty && #check_if {
-                        if let ::std::option::Option::Some(value) = #crate_name::types::ToJSON::to_json(&self.#field_ident) {
+                        if let ::std::option::Option::Some(value) = #serialize_function(&self.#field_ident) {
                             object.insert(::std::string::ToString::to_string(#field_name), value);
                         }
                     }

--- a/poem-openapi-derive/src/object.rs
+++ b/poem-openapi-derive/src/object.rs
@@ -203,7 +203,7 @@ pub(crate) fn generate(args: DeriveInput) -> GeneratorResult<TokenStream> {
                         Some(ref function) => quote! { #function },
                         None => quote! { #crate_name::types::ParseFromJSON::parse_from_json },
                     };
-                    
+
                     deserialize_fields.push(quote! {
                         #[allow(non_snake_case)]
                         let #field_ident: #field_ty = {

--- a/poem-openapi-derive/src/object.rs
+++ b/poem-openapi-derive/src/object.rs
@@ -201,7 +201,7 @@ pub(crate) fn generate(args: DeriveInput) -> GeneratorResult<TokenStream> {
                 None => {
                     let deserialize_function = match field.deserialize_with {
                         Some(ref function) => quote! { #function },
-                        None => quote!{ #crate_name::types::ParseFromJSON::parse_from_json }
+                        None => quote! { #crate_name::types::ParseFromJSON::parse_from_json }
                     };
                     
                     deserialize_fields.push(quote! {
@@ -251,8 +251,8 @@ pub(crate) fn generate(args: DeriveInput) -> GeneratorResult<TokenStream> {
                 };
 
                 let serialize_function = match field.serialize_with {
-                    Some(ref function) => quote!{ #function },
-                    None => quote!{ #crate_name::types::ToJSON::to_json },
+                    Some(ref function) => quote! { #function },
+                    None => quote! { #crate_name::types::ToJSON::to_json },
                 };
 
                 serialize_fields.push(quote! {

--- a/poem-openapi-derive/src/object.rs
+++ b/poem-openapi-derive/src/object.rs
@@ -201,7 +201,7 @@ pub(crate) fn generate(args: DeriveInput) -> GeneratorResult<TokenStream> {
                 None => {
                     let deserialize_function = match field.deserialize_with {
                         Some(ref function) => quote! { #function },
-                        None => quote! { #crate_name::types::ParseFromJSON::parse_from_json }
+                        None => quote! { #crate_name::types::ParseFromJSON::parse_from_json },
                     };
                     
                     deserialize_fields.push(quote! {
@@ -213,7 +213,7 @@ pub(crate) fn generate(args: DeriveInput) -> GeneratorResult<TokenStream> {
                             value
                         };
                     })
-                },
+                }
             }
         } else {
             if args.deny_unknown_fields {

--- a/poem-openapi/tests/object.rs
+++ b/poem-openapi/tests/object.rs
@@ -1072,10 +1072,8 @@ fn deserialize_with() {
             .ok_or(poem_openapi::types::ParseError::custom("Unknown error")) // bad error, but its good enough for tests
     }
 
-
     assert_eq!(
         Obj::parse_from_json(Some(json!({"a": "3 + 4"}))).unwrap(),
         Obj { a: 7 }
     );
 }
-

--- a/poem-openapi/tests/object.rs
+++ b/poem-openapi/tests/object.rs
@@ -1023,8 +1023,8 @@ fn object_default_override_by_field() {
 //NOTE(Rennorb): The `serialize_with` and `deserialize_with` attributes don't add any additional validation,
 // it's up to the library consumer to use them in ways were they don't violate the OpenAPI specification of the underlying type.
 //
-// In practice `serialize_with` only exists for the rounding case above, which could not be implemented in a different way before this,
-// and `deserialize_with` only exists for parity.
+// In practice `serialize_with` only exists for the rounding case below, which could not be implemented in a different way before this
+// (only by using a larger type), and `deserialize_with` just exists for parity.
 
 #[test]
 fn serialize_with() {

--- a/poem-openapi/tests/object.rs
+++ b/poem-openapi/tests/object.rs
@@ -1019,3 +1019,55 @@ fn object_default_override_by_field() {
         }
     );
 }
+
+//NOTE(Rennorb): The `serialize_with` and `deserialize_with` attributes don't add any additional validation,
+// it's up to the library consumer to use them in ways were they don't violate the OpenAPI specification of the underlying type.
+//
+// In practice `serialize_with` only exists for the rounding case above, which could not be implemented in a different way before this,
+// and `deserialize_with` only exists for parity.
+
+#[test]
+fn serialize_with() {
+    #[derive(Debug, Object)]
+    struct Obj {
+        #[oai(serialize_with = "round")]
+        a: f32,
+        b: f32,
+    }
+
+    //NOTE(Rennorb): Function signature in complice with `to_json` in the Type system.
+    // Would prefer the usual way of implementing this with a serializer reference, but this has to do for now.
+    fn round(v : &f32) -> Option<serde_json::Value> {
+        Some(serde_json::Value::from((*v as f64 * 1e5).round() / 1e5))
+    }
+
+    let obj = Obj { a: 0.3, b: 0.3 };
+
+    assert_eq!(obj.to_json(), Some(json!({"a": 0.3f64, "b": 0.3f32})));
+}
+
+#[test]
+fn deserialize_with() {
+    #[derive(Debug, PartialEq, Object)]
+    struct Obj {
+        #[oai(deserialize_with = "add")]
+        a: i32,
+    }
+
+    //NOTE(Rennorb): Function signature in complice with `parse_from_json` in the Type system.
+    // Would prefer the usual way of implementing this with a serializer reference, but this has to do for now.
+    fn add(value: Option<serde_json::Value>) -> poem_openapi::types::ParseResult<i32> {
+        value.as_ref().and_then(|v| v.as_str()).and_then(|s| s.split_once('+')).and_then(|(a, b)| {
+            let parse_a = a.trim().parse::<i32>();
+            let parse_b = b.trim().parse::<i32>();
+            match (parse_a, parse_b) {
+                (Ok(int_a), Ok(int_b)) => Some(int_a + int_b),
+                _ => None,
+            }
+        }).ok_or(poem_openapi::types::ParseError::custom("Unknown error")) // bad error, but its good enough for tests
+    }
+
+
+    assert_eq!(Obj::parse_from_json(Some(json!({"a": "3 + 4"}))).unwrap(), Obj { a: 7 });
+}
+

--- a/poem-openapi/tests/object.rs
+++ b/poem-openapi/tests/object.rs
@@ -1020,7 +1020,7 @@ fn object_default_override_by_field() {
     );
 }
 
-//NOTE(Rennorb): The `serialize_with` and `deserialize_with` attributes don't add any additional validation,
+// NOTE(Rennorb): The `serialize_with` and `deserialize_with` attributes don't add any additional validation,
 // it's up to the library consumer to use them in ways were they don't violate the OpenAPI specification of the underlying type.
 //
 // In practice `serialize_with` only exists for the rounding case below, which could not be implemented in a different way before this
@@ -1035,9 +1035,9 @@ fn serialize_with() {
         b: f32,
     }
 
-    //NOTE(Rennorb): Function signature in complice with `to_json` in the Type system.
+    // NOTE(Rennorb): Function signature in complice with `to_json` in the Type system.
     // Would prefer the usual way of implementing this with a serializer reference, but this has to do for now.
-    fn round(v : &f32) -> Option<serde_json::Value> {
+    fn round(v: &f32) -> Option<serde_json::Value> {
         Some(serde_json::Value::from((*v as f64 * 1e5).round() / 1e5))
     }
 
@@ -1054,20 +1054,28 @@ fn deserialize_with() {
         a: i32,
     }
 
-    //NOTE(Rennorb): Function signature in complice with `parse_from_json` in the Type system.
+    // NOTE(Rennorb): Function signature in complice with `parse_from_json` in the Type system.
     // Would prefer the usual way of implementing this with a serializer reference, but this has to do for now.
     fn add(value: Option<serde_json::Value>) -> poem_openapi::types::ParseResult<i32> {
-        value.as_ref().and_then(|v| v.as_str()).and_then(|s| s.split_once('+')).and_then(|(a, b)| {
-            let parse_a = a.trim().parse::<i32>();
-            let parse_b = b.trim().parse::<i32>();
-            match (parse_a, parse_b) {
-                (Ok(int_a), Ok(int_b)) => Some(int_a + int_b),
-                _ => None,
-            }
-        }).ok_or(poem_openapi::types::ParseError::custom("Unknown error")) // bad error, but its good enough for tests
+        value
+            .as_ref()
+            .and_then(|v| v.as_str())
+            .and_then(|s| s.split_once('+'))
+            .and_then(|(a, b)| {
+                let parse_a = a.trim().parse::<i32>();
+                let parse_b = b.trim().parse::<i32>();
+                match (parse_a, parse_b) {
+                    (Ok(int_a), Ok(int_b)) => Some(int_a + int_b),
+                    _ => None,
+                }
+            })
+            .ok_or(poem_openapi::types::ParseError::custom("Unknown error")) // bad error, but its good enough for tests
     }
 
 
-    assert_eq!(Obj::parse_from_json(Some(json!({"a": "3 + 4"}))).unwrap(), Obj { a: 7 });
+    assert_eq!(
+        Obj::parse_from_json(Some(json!({"a": "3 + 4"}))).unwrap(),
+        Obj { a: 7 }
+    );
 }
 


### PR DESCRIPTION
Heads up: I did not run all tests locally as the dependencies don't properly resolve without installing additional stuff, but the 'object' tests run fine (if you specify the `time` dependency).

I fully understand if you don't want to merge this in the public version, as it does not come with safety features and allows the consumer of the library to violate the generated OAI spec (see comment in tests).

Also I didn't figure out where to put the documentation, so if you point me to it I will still add that.

closes #585 as far as I can tell.