### PR TITLE
poem-openapi: Replace `naive-date` with `date`

### DIFF
--- a/poem-openapi/src/types/external/chrono.rs
+++ b/poem-openapi/src/types/external/chrono.rs
@@ -143,7 +143,7 @@ macro_rules! impl_naive_datetime_types {
 }
 
 impl_naive_datetime_types!(NaiveDateTime, "string", "naive-date-time", "{:?}");
-impl_naive_datetime_types!(NaiveDate, "string", "naive-date", "{}");
+impl_naive_datetime_types!(NaiveDate, "string", "date", "{}");
 impl_naive_datetime_types!(NaiveTime, "string", "naive-time", "{}");
 
 #[cfg(test)]

--- a/poem-openapi/src/types/external/time.rs
+++ b/poem-openapi/src/types/external/time.rs
@@ -146,7 +146,7 @@ impl_naive_datetime_types!(
 impl_naive_datetime_types!(
     Date,
     "string",
-    "naive-date",
+    "date",
     format_description!("[year]-[month]-[day]")
 );
 impl_naive_datetime_types!(


### PR DESCRIPTION
When a date type was specified in an openapi Object, it was previously set to the format `naive-date`, which isn't recognized by doc-generators.

This replaces the openapi text format `naive-date` with `date`, aligning with the [OAS definition](https://spec.openapis.org/oas/v3.0.3#data-types) which uses RFC3339 full-date (which is naive by def).

It enables doc-generators (e.g. rapidoc) to generate examples when the schema contains a `time::Date` or `chrono::NaiveDate` field.