### PR TITLE
Update opentelemetry-jaeger to use OTLP

### DIFF
--- a/examples/poem/opentelemetry-jaeger/Cargo.toml
+++ b/examples/poem/opentelemetry-jaeger/Cargo.toml
@@ -9,12 +9,10 @@ poem = { workspace = true, features = ["opentelemetry"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tracing-subscriber.workspace = true
 opentelemetry = { version = "0.21.0", features = ["metrics"] }
-opentelemetry_sdk = "0.21.0"
+opentelemetry_sdk = { version = "0.21.0", features = ["rt-tokio"] }
 opentelemetry-http = { version = "0.10.0" }
-opentelemetry-jaeger = { version = "0.20.0", features = [
-    "rt-tokio",
-    "collector_client",
-    "hyper_collector_client",
+opentelemetry-otlp = { version = "0.14.0", features = [
+    "trace",
 ] }
 reqwest = "0.11.6"
 

--- a/examples/poem/opentelemetry-jaeger/README.md
+++ b/examples/poem/opentelemetry-jaeger/README.md
@@ -3,7 +3,7 @@
 First make sure you have a running version of the Jaeger instance you want to send data to:
 
 ```shell
-docker run -d -p6831:6831/udp -p6832:6832/udp -p16686:16686 -p14268:14268 jaegertracing/all-in-one:latest
+docker run -e COLLECTOR_OTLP_ENABLED=true -p 4317:4317 -p 4318:4318 -p16686:16686 -p14268:14268 jaegertracing/all-in-one:latest
 ```
 
 Launch the servers:

--- a/examples/poem/opentelemetry-jaeger/src/client.rs
+++ b/examples/poem/opentelemetry-jaeger/src/client.rs
@@ -6,17 +6,20 @@ use opentelemetry::{
     Context, KeyValue,
 };
 use opentelemetry_http::HeaderInjector;
-use opentelemetry_sdk::{propagation::TraceContextPropagator, trace::Tracer};
+use opentelemetry_sdk::{propagation::TraceContextPropagator, trace::Tracer, Resource};
 use reqwest::{Client, Method, Url};
 
 fn init_tracer() -> Tracer {
     global::set_text_map_propagator(TraceContextPropagator::new());
-    opentelemetry_jaeger::new_collector_pipeline()
-        .with_service_name("poem")
-        .with_endpoint("http://localhost:14268/api/traces")
-        .with_hyper()
+    opentelemetry_otlp::new_pipeline()
+        .tracing()
+        .with_trace_config(
+            opentelemetry_sdk::trace::config()
+                .with_resource(Resource::new(vec![KeyValue::new("service.name", "poem")])),
+        )
+        .with_exporter(opentelemetry_otlp::new_exporter().tonic())
         .install_batch(opentelemetry_sdk::runtime::Tokio)
-        .unwrap()
+        .expect("Trace Pipeline should initialize.")
 }
 
 #[tokio::main]


### PR DESCRIPTION
Jaeger has been compatibile with OTLP for over 2 years. We want to encourage usage of OTLP exporter.

https://github.com/open-telemetry/opentelemetry-rust/issues/995