### PR TITLE
Fixup to e3b2201f: prevent open::that from blocking, fix a typo, minor code simplification

### DIFF
--- a/examples/poem/local-server-with-browser/src/main.rs
+++ b/examples/poem/local-server-with-browser/src/main.rs
@@ -19,8 +19,8 @@ async fn main() -> Result<(), std::io::Error> {
 
     // To test port assignment, run two instances of this example at once.
     //
-    // For ports <1024, running with administrator priveleges would be needed on
-    // Unix. For port 0, the OS would assign a port and we'd need to find out
+    // For ports <1024, running with administrator priveledges would be needed
+    // on Unix. For port 0, the OS would assign a port and we'd need to find out
     // what that port's number is.
     let (min_port, max_port) = (8080, 8085);
     // Using 127.0.0.1 instead of 0.0.0.0 for security; a local server should
@@ -32,24 +32,22 @@ async fn main() -> Result<(), std::io::Error> {
         if port > max_port {
             return Err(error.unwrap());
         }
-        let listener = TcpListener::bind(format!("{hostname}:{}", port));
+        let listener = TcpListener::bind(format!("{hostname}:{port}"));
         match listener.into_acceptor().await {
             Ok(a) => break a,
-            Err(err) => {
-                // Most likely, another application is bound to this port.
-                eprintln!("Couldn't bind to port {port}.");
-                error = Some(err)
-            }
+            Err(err) => error = Some(err),
         };
+        // Most likely, another application is bound to this port.
+        eprintln!("Couldn't bind to port {port}.");
         port += 1;
     };
 
     // Now that the acceptor exists, the browser should be able to connect
+    eprintln!("Listening at {hostname}:{port}.");
     let http_address = format!("http://{hostname}:{port}/");
-    eprintln!("Listening at {http_address}.");
     eprint!("Trying to launch a browser at {http_address}...");
     match open::that(&http_address) {
-        Ok(_) => eprintln!(" Success!"),
+        Ok(()) => eprintln!(" Success!"),
         Err(err) => eprintln!("\nFailed to launch a browser: {err}"),
     }
 


### PR DESCRIPTION
`open::that` can block, for example when `firefox` is the default browser
on Linux and no instance of `firefox` is running.

-------------
Perhaps `tokio::spawn_blocking` with `open::that` would be better in terms of error handling than using `that_detached`. The latter does not report an error if the browser exits with an error code. OTOH, with `open::that`, killing the server might kill the browser...