### PR TITLE
feat(afit): replace `async-trait` with AFIT

### DIFF
--- a/poem-derive/src/lib.rs
+++ b/poem-derive/src/lib.rs
@@ -100,7 +100,6 @@ fn generate_handler(internal: bool, input: TokenStream) -> Result<TokenStream> {
         #[allow(non_camel_case_types)]
         #def_struct
 
-        #[#crate_name::async_trait]
         impl #impl_generics #crate_name::Endpoint for #ident #type_generics #where_clause {
             type Output = #crate_name::Response;
 

--- a/poem/Cargo.toml
+++ b/poem/Cargo.toml
@@ -70,7 +70,7 @@ yaml = ["serde_yaml"]
 [dependencies]
 poem-derive.workspace = true
 
-async-trait = "0.1.51"
+trait-make = "0.1"
 bytes.workspace = true
 futures-util = { workspace = true, features = ["sink"] }
 http = "1.0.0"

--- a/poem/src/endpoint/after.rs
+++ b/poem/src/endpoint/after.rs
@@ -15,7 +15,6 @@ impl<E, F> After<E, F> {
     }
 }
 
-#[async_trait::async_trait]
 impl<E, F, Fut, T> Endpoint for After<E, F>
 where
     E: Endpoint,

--- a/poem/src/endpoint/and_then.rs
+++ b/poem/src/endpoint/and_then.rs
@@ -15,7 +15,6 @@ impl<E, F> AndThen<E, F> {
     }
 }
 
-#[async_trait::async_trait]
 impl<E, F, Fut, R, R2> Endpoint for AndThen<E, F>
 where
     E: Endpoint<Output = R>,

--- a/poem/src/endpoint/around.rs
+++ b/poem/src/endpoint/around.rs
@@ -18,7 +18,6 @@ impl<E, F> Around<E, F> {
     }
 }
 
-#[async_trait::async_trait]
 impl<E, F, Fut, T> Endpoint for Around<E, F>
 where
     E: Endpoint,

--- a/poem/src/endpoint/before.rs
+++ b/poem/src/endpoint/before.rs
@@ -15,7 +15,6 @@ impl<E, F> Before<E, F> {
     }
 }
 
-#[async_trait::async_trait]
 impl<E, F, Fut> Endpoint for Before<E, F>
 where
     E: Endpoint,

--- a/poem/src/endpoint/catch_all_error.rs
+++ b/poem/src/endpoint/catch_all_error.rs
@@ -21,7 +21,6 @@ impl<E, F, R> CatchAllError<E, F, R> {
     }
 }
 
-#[async_trait::async_trait]
 impl<E, F, Fut, R> Endpoint for CatchAllError<E, F, R>
 where
     E: Endpoint,

--- a/poem/src/endpoint/catch_error.rs
+++ b/poem/src/endpoint/catch_error.rs
@@ -22,7 +22,6 @@ impl<E, F, R, ErrType> CatchError<E, F, R, ErrType> {
     }
 }
 
-#[async_trait::async_trait]
 impl<E, F, Fut, R, ErrType> Endpoint for CatchError<E, F, R, ErrType>
 where
     E: Endpoint,

--- a/poem/src/endpoint/embed.rs
+++ b/poem/src/endpoint/embed.rs
@@ -1,6 +1,5 @@
 use std::marker::PhantomData;
 
-use async_trait::async_trait;
 use rust_embed::RustEmbed;
 
 use crate::{
@@ -26,7 +25,6 @@ impl<E: RustEmbed + Send + Sync> EmbeddedFileEndpoint<E> {
     }
 }
 
-#[async_trait]
 impl<E: RustEmbed + Send + Sync> Endpoint for EmbeddedFileEndpoint<E> {
     type Output = Response;
 
@@ -81,7 +79,6 @@ impl<E: RustEmbed + Send + Sync> EmbeddedFilesEndpoint<E> {
     }
 }
 
-#[async_trait]
 impl<E: RustEmbed + Send + Sync> Endpoint for EmbeddedFilesEndpoint<E> {
     type Output = Response;
 

--- a/poem/src/endpoint/endpoint.rs
+++ b/poem/src/endpoint/endpoint.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 /// An HTTP request handler.
-#[async_trait::async_trait]
+#[trait_make::make(Send)]
 pub trait Endpoint: Send + Sync {
     /// Represents the response of the endpoint.
     type Output: IntoResponse;
@@ -58,7 +58,6 @@ struct SyncFnEndpoint<T, F> {
     f: F,
 }
 
-#[async_trait::async_trait]
 impl<F, T, R> Endpoint for SyncFnEndpoint<T, F>
 where
     F: Fn(Request) -> R + Send + Sync,
@@ -77,7 +76,6 @@ struct AsyncFnEndpoint<T, F> {
     f: F,
 }
 
-#[async_trait::async_trait]
 impl<F, Fut, T, R> Endpoint for AsyncFnEndpoint<T, F>
 where
     F: Fn(Request) -> Fut + Sync + Send,
@@ -98,7 +96,6 @@ pub enum EitherEndpoint<A, B> {
     B(B),
 }
 
-#[async_trait::async_trait]
 impl<A, B> Endpoint for EitherEndpoint<A, B>
 where
     A: Endpoint,
@@ -175,7 +172,6 @@ where
     }
 }
 
-#[async_trait::async_trait]
 impl<T: Endpoint + ?Sized> Endpoint for &T {
     type Output = T::Output;
 
@@ -184,7 +180,6 @@ impl<T: Endpoint + ?Sized> Endpoint for &T {
     }
 }
 
-#[async_trait::async_trait]
 impl<T: Endpoint + ?Sized> Endpoint for Box<T> {
     type Output = T::Output;
 
@@ -193,7 +188,6 @@ impl<T: Endpoint + ?Sized> Endpoint for Box<T> {
     }
 }
 
-#[async_trait::async_trait]
 impl<T: Endpoint + ?Sized> Endpoint for Arc<T> {
     type Output = T::Output;
 

--- a/poem/src/endpoint/inspect_all_err.rs
+++ b/poem/src/endpoint/inspect_all_err.rs
@@ -14,7 +14,6 @@ impl<E, F> InspectAllError<E, F> {
     }
 }
 
-#[async_trait::async_trait]
 impl<E, F> Endpoint for InspectAllError<E, F>
 where
     E: Endpoint,

--- a/poem/src/endpoint/inspect_err.rs
+++ b/poem/src/endpoint/inspect_err.rs
@@ -21,7 +21,6 @@ impl<E, F, ErrType> InspectError<E, F, ErrType> {
     }
 }
 
-#[async_trait::async_trait]
 impl<E, F, ErrType> Endpoint for InspectError<E, F, ErrType>
 where
     E: Endpoint,

--- a/poem/src/endpoint/map.rs
+++ b/poem/src/endpoint/map.rs
@@ -15,7 +15,6 @@ impl<E, F> Map<E, F> {
     }
 }
 
-#[async_trait::async_trait]
 impl<E, F, Fut, R, R2> Endpoint for Map<E, F>
 where
     E: Endpoint<Output = R>,

--- a/poem/src/endpoint/map_to_response.rs
+++ b/poem/src/endpoint/map_to_response.rs
@@ -13,7 +13,6 @@ impl<E> MapToResponse<E> {
     }
 }
 
-#[async_trait::async_trait]
 impl<E: Endpoint> Endpoint for MapToResponse<E> {
     type Output = Response;
 

--- a/poem/src/endpoint/prometheus_exporter.rs
+++ b/poem/src/endpoint/prometheus_exporter.rs
@@ -43,7 +43,6 @@ pub struct PrometheusExporterEndpoint {
     registry: Registry,
 }
 
-#[async_trait::async_trait]
 impl Endpoint for PrometheusExporterEndpoint {
     type Output = Response;
 

--- a/poem/src/endpoint/static_files.rs
+++ b/poem/src/endpoint/static_files.rs
@@ -161,7 +161,6 @@ impl StaticFilesEndpoint {
     }
 }
 
-#[async_trait::async_trait]
 impl Endpoint for StaticFilesEndpoint {
     type Output = Response;
 
@@ -315,7 +314,6 @@ impl StaticFileEndpoint {
     }
 }
 
-#[async_trait::async_trait]
 impl Endpoint for StaticFileEndpoint {
     type Output = Response;
 

--- a/poem/src/endpoint/to_response.rs
+++ b/poem/src/endpoint/to_response.rs
@@ -13,7 +13,6 @@ impl<E> ToResponse<E> {
     }
 }
 
-#[async_trait::async_trait]
 impl<E: Endpoint> Endpoint for ToResponse<E> {
     type Output = Response;
 

--- a/poem/src/endpoint/tower_compat.rs
+++ b/poem/src/endpoint/tower_compat.rs
@@ -38,7 +38,6 @@ impl<T> TowerCompatExt for T {}
 #[cfg_attr(docsrs, doc(cfg(feature = "tower-compat")))]
 pub struct TowerCompatEndpoint<Svc>(Svc);
 
-#[async_trait::async_trait]
 impl<Svc, ResBody, Err, Fut> Endpoint for TowerCompatEndpoint<Svc>
 where
     ResBody: hyper::body::Body + Send + Sync + 'static,

--- a/poem/src/i18n/locale.rs
+++ b/poem/src/i18n/locale.rs
@@ -84,7 +84,6 @@ impl Locale {
     }
 }
 
-#[async_trait::async_trait]
 impl<'a> FromRequest<'a> for Locale {
     async fn from_request(req: &'a Request, _body: &mut RequestBody) -> Result<Self> {
         let resources = req

--- a/poem/src/lib.rs
+++ b/poem/src/lib.rs
@@ -294,7 +294,6 @@ mod route;
 mod server;
 
 pub use addr::Addr;
-pub use async_trait::async_trait;
 pub use body::Body;
 pub use endpoint::{Endpoint, EndpointExt, IntoEndpoint};
 pub use error::{Error, Result};

--- a/poem/src/listener/acme/endpoint.rs
+++ b/poem/src/listener/acme/endpoint.rs
@@ -38,7 +38,6 @@ pub struct Http01Endpoint {
     pub keys: Http01TokensMap,
 }
 
-#[async_trait::async_trait]
 impl Endpoint for Http01Endpoint {
     type Output = Response;
 

--- a/poem/src/listener/acme/listener.rs
+++ b/poem/src/listener/acme/listener.rs
@@ -76,7 +76,6 @@ impl<T> ResolvedCertListener<T> {
     }
 }
 
-#[async_trait::async_trait]
 impl<T: Listener> Listener for ResolvedCertListener<T> {
     type Acceptor = AutoCertAcceptor<T::Acceptor>;
 
@@ -97,7 +96,6 @@ impl<T> AutoCertListener<T> {
     }
 }
 
-#[async_trait::async_trait]
 impl<T: Listener> Listener for AutoCertListener<T> {
     type Acceptor = AutoCertAcceptor<T::Acceptor>;
 
@@ -216,7 +214,6 @@ pub struct AutoCertAcceptor<T> {
     acceptor: TlsAcceptor,
 }
 
-#[async_trait::async_trait]
 impl<T: Acceptor> Acceptor for AutoCertAcceptor<T> {
     type Io = HandshakeStream<TlsStream<T::Io>>;
 

--- a/poem/src/listener/combined.rs
+++ b/poem/src/listener/combined.rs
@@ -24,7 +24,6 @@ impl<A, B> Combined<A, B> {
     }
 }
 
-#[async_trait::async_trait]
 impl<A: Listener, B: Listener> Listener for Combined<A, B> {
     type Acceptor = Combined<A::Acceptor, B::Acceptor>;
 
@@ -36,7 +35,6 @@ impl<A: Listener, B: Listener> Listener for Combined<A, B> {
     }
 }
 
-#[async_trait::async_trait]
 impl<A: Acceptor, B: Acceptor> Acceptor for Combined<A, B> {
     type Io = CombinedStream<A::Io, B::Io>;
 

--- a/poem/src/listener/mod.rs
+++ b/poem/src/listener/mod.rs
@@ -50,7 +50,7 @@ pub use self::{
 use crate::web::{LocalAddr, RemoteAddr};
 
 /// Represents a acceptor type.
-#[async_trait::async_trait]
+#[trait_make::make(Send)]
 pub trait Acceptor: Send {
     /// IO stream type.
     type Io: AsyncRead + AsyncWrite + Send + Unpin + 'static;
@@ -126,7 +126,7 @@ pub trait AcceptorExt: Acceptor {
 impl<T: Acceptor> AcceptorExt for T {}
 
 /// Represents a listener that can be listens for incoming connections.
-#[async_trait::async_trait]
+#[trait_make::make(Send)]
 pub trait Listener: Send {
     /// The acceptor type.
     type Acceptor: Acceptor;
@@ -232,7 +232,6 @@ pub trait Listener: Send {
     }
 }
 
-#[async_trait::async_trait]
 impl Listener for Infallible {
     type Acceptor = Infallible;
 
@@ -241,7 +240,6 @@ impl Listener for Infallible {
     }
 }
 
-#[async_trait::async_trait]
 impl<T: Listener + Sized> Listener for Box<T> {
     type Acceptor = T::Acceptor;
 
@@ -250,7 +248,6 @@ impl<T: Listener + Sized> Listener for Box<T> {
     }
 }
 
-#[async_trait::async_trait]
 impl<T: Acceptor + ?Sized> Acceptor for Box<T> {
     type Io = T::Io;
 
@@ -263,7 +260,6 @@ impl<T: Acceptor + ?Sized> Acceptor for Box<T> {
     }
 }
 
-#[async_trait::async_trait]
 impl Acceptor for Infallible {
     type Io = BoxIo;
 
@@ -334,7 +330,6 @@ impl BoxListener {
     }
 }
 
-#[async_trait::async_trait]
 impl Listener for BoxListener {
     type Acceptor = BoxAcceptor;
 
@@ -345,7 +340,6 @@ impl Listener for BoxListener {
 
 struct WrappedAcceptor<T: Acceptor>(T);
 
-#[async_trait::async_trait]
 impl<T: Acceptor> Acceptor for WrappedAcceptor<T> {
     type Io = BoxIo;
 

--- a/poem/src/listener/native_tls.rs
+++ b/poem/src/listener/native_tls.rs
@@ -103,7 +103,6 @@ where
     }
 }
 
-#[async_trait::async_trait]
 impl<T: Listener, S: IntoTlsConfigStream<NativeTlsConfig>> Listener for NativeTlsListener<T, S> {
     type Acceptor = NativeTlsAcceptor<T::Acceptor, BoxStream<'static, NativeTlsConfig>>;
 
@@ -136,7 +135,6 @@ where
     }
 }
 
-#[async_trait::async_trait]
 impl<T, S> Acceptor for NativeTlsAcceptor<T, S>
 where
     S: Stream<Item = NativeTlsConfig> + Send + Unpin + 'static,

--- a/poem/src/listener/openssl_tls.rs
+++ b/poem/src/listener/openssl_tls.rs
@@ -148,7 +148,6 @@ where
     }
 }
 
-#[async_trait::async_trait]
 impl<T: Listener, S: IntoTlsConfigStream<OpensslTlsConfig>> Listener for OpensslTlsListener<T, S> {
     type Acceptor = OpensslTlsAcceptor<T::Acceptor, BoxStream<'static, OpensslTlsConfig>>;
 
@@ -181,7 +180,6 @@ where
     }
 }
 
-#[async_trait::async_trait]
 impl<T, S> Acceptor for OpensslTlsAcceptor<T, S>
 where
     S: Stream<Item = OpensslTlsConfig> + Send + Unpin + 'static,

--- a/poem/src/listener/rustls.rs
+++ b/poem/src/listener/rustls.rs
@@ -320,7 +320,6 @@ where
     }
 }
 
-#[async_trait::async_trait]
 impl<T: Listener, S: IntoTlsConfigStream<RustlsConfig>> Listener for RustlsListener<T, S> {
     type Acceptor = RustlsAcceptor<T::Acceptor, BoxStream<'static, RustlsConfig>>;
 
@@ -353,7 +352,6 @@ where
     }
 }
 
-#[async_trait::async_trait]
 impl<T, S> Acceptor for RustlsAcceptor<T, S>
 where
     S: Stream<Item = RustlsConfig> + Send + Unpin + 'static,

--- a/poem/src/listener/tcp.rs
+++ b/poem/src/listener/tcp.rs
@@ -23,7 +23,6 @@ impl<T> TcpListener<T> {
     }
 }
 
-#[async_trait::async_trait]
 impl<T: ToSocketAddrs + Send> Listener for TcpListener<T> {
     type Acceptor = TcpAcceptor;
 
@@ -63,7 +62,6 @@ impl TcpAcceptor {
     }
 }
 
-#[async_trait::async_trait]
 impl Acceptor for TcpAcceptor {
     type Io = TcpStream;
 

--- a/poem/src/listener/unix.rs
+++ b/poem/src/listener/unix.rs
@@ -52,7 +52,6 @@ impl<T> UnixListener<T> {
     }
 }
 
-#[async_trait::async_trait]
 impl<T: AsRef<Path> + Send + Clone> Listener for UnixListener<T> {
     type Acceptor = UnixAcceptor;
 
@@ -104,7 +103,6 @@ impl UnixAcceptor {
     }
 }
 
-#[async_trait::async_trait]
 impl Acceptor for UnixAcceptor {
     type Io = UnixStream;
 

--- a/poem/src/middleware/add_data.rs
+++ b/poem/src/middleware/add_data.rs
@@ -33,7 +33,6 @@ pub struct AddDataEndpoint<E, T> {
     value: T,
 }
 
-#[async_trait::async_trait]
 impl<E, T> Endpoint for AddDataEndpoint<E, T>
 where
     E: Endpoint,

--- a/poem/src/middleware/catch_panic.rs
+++ b/poem/src/middleware/catch_panic.rs
@@ -128,7 +128,6 @@ pub struct CatchPanicEndpoint<E, H> {
     panic_handler: H,
 }
 
-#[async_trait::async_trait]
 impl<E: Endpoint, H: PanicHandler> Endpoint for CatchPanicEndpoint<E, H> {
     type Output = Response;
 

--- a/poem/src/middleware/compression.rs
+++ b/poem/src/middleware/compression.rs
@@ -138,7 +138,6 @@ fn coding_priority(c: &ContentCoding) -> u8 {
     }
 }
 
-#[async_trait::async_trait]
 impl<E: Endpoint> Endpoint for CompressionEndpoint<E> {
     type Output = Response;
 

--- a/poem/src/middleware/cookie_jar_manager.rs
+++ b/poem/src/middleware/cookie_jar_manager.rs
@@ -49,7 +49,6 @@ pub struct CookieJarManagerEndpoint<E> {
     key: Option<Arc<CookieKey>>,
 }
 
-#[async_trait::async_trait]
 impl<E: Endpoint> Endpoint for CookieJarManagerEndpoint<E> {
     type Output = Response;
 

--- a/poem/src/middleware/cors.rs
+++ b/poem/src/middleware/cors.rs
@@ -349,7 +349,6 @@ impl<E: Endpoint> CorsEndpoint<E> {
     }
 }
 
-#[async_trait::async_trait]
 impl<E: Endpoint> Endpoint for CorsEndpoint<E> {
     type Output = Response;
 

--- a/poem/src/middleware/csrf.rs
+++ b/poem/src/middleware/csrf.rs
@@ -199,7 +199,6 @@ impl<E> CsrfEndpoint<E> {
     }
 }
 
-#[async_trait::async_trait]
 impl<E: Endpoint> Endpoint for CsrfEndpoint<E> {
     type Output = E::Output;
 

--- a/poem/src/middleware/force_https.rs
+++ b/poem/src/middleware/force_https.rs
@@ -60,7 +60,6 @@ pub struct ForceHttpsEndpoint<E> {
     filter_fn: Option<FilterFn>,
 }
 
-#[async_trait::async_trait]
 impl<E> Endpoint for ForceHttpsEndpoint<E>
 where
     E: Endpoint,

--- a/poem/src/middleware/mod.rs
+++ b/poem/src/middleware/mod.rs
@@ -225,7 +225,6 @@ mod tests {
             value: HeaderValue,
         }
 
-        #[async_trait::async_trait]
         impl<E: Endpoint> Endpoint for AddHeader<E> {
             type Output = Response;
 

--- a/poem/src/middleware/normalize_path.rs
+++ b/poem/src/middleware/normalize_path.rs
@@ -78,7 +78,6 @@ pub struct NormalizePathEndpoint<E> {
     style: TrailingSlash,
 }
 
-#[async_trait::async_trait]
 impl<E: Endpoint> Endpoint for NormalizePathEndpoint<E> {
     type Output = E::Output;
 

--- a/poem/src/middleware/opentelemetry_metrics.rs
+++ b/poem/src/middleware/opentelemetry_metrics.rs
@@ -69,7 +69,6 @@ pub struct OpenTelemetryMetricsEndpoint<E> {
     inner: E,
 }
 
-#[async_trait::async_trait]
 impl<E: Endpoint> Endpoint for OpenTelemetryMetricsEndpoint<E> {
     type Output = Response;
 

--- a/poem/src/middleware/opentelemetry_tracing.rs
+++ b/poem/src/middleware/opentelemetry_tracing.rs
@@ -67,7 +67,6 @@ impl<'a> Extractor for HeaderExtractor<'a> {
     }
 }
 
-#[async_trait::async_trait]
 impl<T, E> Endpoint for OpenTelemetryTracingEndpoint<T, E>
 where
     T: Tracer + Send + Sync,

--- a/poem/src/middleware/propagate_header.rs
+++ b/poem/src/middleware/propagate_header.rs
@@ -47,7 +47,6 @@ pub struct PropagateHeaderEndpoint<E> {
     headers: HashSet<HeaderName>,
 }
 
-#[async_trait::async_trait]
 impl<E: Endpoint> Endpoint for PropagateHeaderEndpoint<E> {
     type Output = Response;
 

--- a/poem/src/middleware/sensitive_header.rs
+++ b/poem/src/middleware/sensitive_header.rs
@@ -91,7 +91,6 @@ pub struct SensitiveHeaderEndpoint<E> {
     applied_to: AppliedTo,
 }
 
-#[async_trait::async_trait]
 impl<E: Endpoint> Endpoint for SensitiveHeaderEndpoint<E> {
     type Output = Response;
 

--- a/poem/src/middleware/set_header.rs
+++ b/poem/src/middleware/set_header.rs
@@ -109,7 +109,6 @@ pub struct SetHeaderEndpoint<E> {
     actions: Vec<Action>,
 }
 
-#[async_trait::async_trait]
 impl<E: Endpoint> Endpoint for SetHeaderEndpoint<E> {
     type Output = Response;
 

--- a/poem/src/middleware/size_limit.rs
+++ b/poem/src/middleware/size_limit.rs
@@ -38,7 +38,6 @@ pub struct SizeLimitEndpoint<E> {
     max_size: usize,
 }
 
-#[async_trait::async_trait]
 impl<E: Endpoint> Endpoint for SizeLimitEndpoint<E> {
     type Output = E::Output;
 

--- a/poem/src/middleware/tokio_metrics_mw.rs
+++ b/poem/src/middleware/tokio_metrics_mw.rs
@@ -77,7 +77,6 @@ pub struct TokioMetricsEndpoint<E> {
     monitor: TaskMonitor,
 }
 
-#[async_trait::async_trait]
 impl<E: Endpoint> Endpoint for TokioMetricsEndpoint<E> {
     type Output = Response;
 

--- a/poem/src/middleware/tower_compat.rs
+++ b/poem/src/middleware/tower_compat.rs
@@ -81,7 +81,6 @@ where
 /// An tower service to endpoint adapter.
 pub struct TowerServiceToEndpoint<Svc: Service<Request>>(Buffer<Svc, Request>);
 
-#[async_trait::async_trait]
 impl<Svc> Endpoint for TowerServiceToEndpoint<Svc>
 where
     Svc: Service<Request> + Send + 'static,

--- a/poem/src/middleware/tracing_mw.rs
+++ b/poem/src/middleware/tracing_mw.rs
@@ -24,7 +24,6 @@ pub struct TracingEndpoint<E> {
     inner: E,
 }
 
-#[async_trait::async_trait]
 impl<E: Endpoint> Endpoint for TracingEndpoint<E> {
     type Output = Response;
 

--- a/poem/src/route/router.rs
+++ b/poem/src/route/router.rs
@@ -244,7 +244,6 @@ impl Route {
             prefix_for_path_pattern: usize,
         }
 
-        #[async_trait::async_trait]
         impl<E: Endpoint> Endpoint for Nest<E> {
             type Output = Response;
 
@@ -327,7 +326,6 @@ impl Route {
 #[derive(Debug, Clone)]
 pub struct PathPattern(pub Arc<str>);
 
-#[async_trait::async_trait]
 impl Endpoint for Route {
     type Output = Response;
 
@@ -652,7 +650,6 @@ mod tests {
         inner: E,
     }
 
-    #[async_trait::async_trait]
     impl<E: Endpoint> Endpoint for PathPatternSpyEndpoint<E> {
         type Output = Response;
 
@@ -723,7 +720,6 @@ mod tests {
 
     struct ErrorEndpoint;
 
-    #[async_trait::async_trait]
     impl Endpoint for ErrorEndpoint {
         type Output = Response;
 

--- a/poem/src/route/router_domain.rs
+++ b/poem/src/route/router_domain.rs
@@ -87,7 +87,6 @@ impl RouteDomain {
     }
 }
 
-#[async_trait::async_trait]
 impl Endpoint for RouteDomain {
     type Output = Response;
 

--- a/poem/src/route/router_method.rs
+++ b/poem/src/route/router_method.rs
@@ -163,7 +163,6 @@ impl RouteMethod {
     }
 }
 
-#[async_trait::async_trait]
 impl Endpoint for RouteMethod {
     type Output = Response;
 

--- a/poem/src/route/router_scheme.rs
+++ b/poem/src/route/router_scheme.rs
@@ -72,7 +72,6 @@ impl RouteScheme {
     }
 }
 
-#[async_trait::async_trait]
 impl Endpoint for RouteScheme {
     type Output = Response;
 

--- a/poem/src/session/cookie_session.rs
+++ b/poem/src/session/cookie_session.rs
@@ -42,7 +42,6 @@ pub struct CookieSessionEndpoint<E> {
     config: Arc<CookieConfig>,
 }
 
-#[async_trait::async_trait]
 impl<E: Endpoint> Endpoint for CookieSessionEndpoint<E> {
     type Output = E::Output;
 

--- a/poem/src/session/memory_storage.rs
+++ b/poem/src/session/memory_storage.rs
@@ -68,7 +68,6 @@ impl MemoryStorage {
     }
 }
 
-#[async_trait::async_trait]
 impl SessionStorage for MemoryStorage {
     async fn load_session(&self, session_id: &str) -> Result<Option<BTreeMap<String, Value>>> {
         let inner = self.inner.lock();

--- a/poem/src/session/redis_storage.rs
+++ b/poem/src/session/redis_storage.rs
@@ -22,7 +22,6 @@ impl<T> RedisStorage<T> {
     }
 }
 
-#[async_trait::async_trait]
 impl<T: ConnectionLike + Clone + Sync + Send> SessionStorage for RedisStorage<T> {
     async fn load_session(&self, session_id: &str) -> Result<Option<BTreeMap<String, Value>>> {
         let data: Option<String> = Cmd::get(session_id)

--- a/poem/src/session/server_session.rs
+++ b/poem/src/session/server_session.rs
@@ -52,7 +52,6 @@ pub struct ServerSessionEndpoint<T, E> {
     storage: Arc<T>,
 }
 
-#[async_trait::async_trait]
 impl<T, E> Endpoint for ServerSessionEndpoint<T, E>
 where
     T: SessionStorage,

--- a/poem/src/session/session.rs
+++ b/poem/src/session/session.rs
@@ -147,7 +147,6 @@ impl Session {
     }
 }
 
-#[async_trait::async_trait]
 impl<'a> FromRequest<'a> for &'a Session {
     async fn from_request(req: &'a Request, _body: &mut RequestBody) -> Result<Self> {
         Ok(req

--- a/poem/src/session/session_storage.rs
+++ b/poem/src/session/session_storage.rs
@@ -5,7 +5,7 @@ use serde_json::Value;
 use crate::Result;
 
 /// Represents a back-end session storage.
-#[async_trait::async_trait]
+#[trait_make::make(Send)]
 pub trait SessionStorage: Send + Sync {
     /// Load session entries.
     async fn load_session(&self, session_id: &str) -> Result<Option<BTreeMap<String, Value>>>;

--- a/poem/src/web/accept.rs
+++ b/poem/src/web/accept.rs
@@ -26,7 +26,6 @@ fn parse_accept(headers: &HeaderMap) -> Vec<Mime> {
     items.into_iter().map(|(mime, _)| mime).collect()
 }
 
-#[async_trait::async_trait]
 impl<'a> FromRequest<'a> for Accept {
     async fn from_request(req: &'a Request, _body: &mut RequestBody) -> Result<Self> {
         Ok(Self(parse_accept(req.headers())))

--- a/poem/src/web/cookie.rs
+++ b/poem/src/web/cookie.rs
@@ -291,7 +291,6 @@ impl Cookie {
     }
 }
 
-#[async_trait::async_trait]
 impl<'a> FromRequest<'a> for Cookie {
     async fn from_request(req: &'a Request, _body: &mut RequestBody) -> Result<Self> {
         let value = req
@@ -501,7 +500,6 @@ impl FromStr for CookieJar {
     }
 }
 
-#[async_trait::async_trait]
 impl<'a> FromRequest<'a> for &'a CookieJar {
     async fn from_request(req: &'a Request, _body: &mut RequestBody) -> Result<Self> {
         Ok(req.cookie())

--- a/poem/src/web/csrf.rs
+++ b/poem/src/web/csrf.rs
@@ -20,7 +20,6 @@ impl Deref for CsrfToken {
     }
 }
 
-#[async_trait::async_trait]
 impl<'a> FromRequest<'a> for &'a CsrfToken {
     async fn from_request(req: &'a Request, _body: &mut RequestBody) -> Result<Self> {
         Ok(req
@@ -49,7 +48,6 @@ impl CsrfVerifier {
     }
 }
 
-#[async_trait::async_trait]
 impl<'a> FromRequest<'a> for &'a CsrfVerifier {
     async fn from_request(req: &'a Request, _body: &mut RequestBody) -> Result<Self> {
         Ok(req

--- a/poem/src/web/data.rs
+++ b/poem/src/web/data.rs
@@ -37,7 +37,6 @@ impl<T> Deref for Data<T> {
     }
 }
 
-#[async_trait::async_trait]
 impl<'a, T: Send + Sync + 'static> FromRequest<'a> for Data<&'a T> {
     async fn from_request(req: &'a Request, _body: &mut RequestBody) -> Result<Self> {
         Ok(Data(

--- a/poem/src/web/form.rs
+++ b/poem/src/web/form.rs
@@ -86,7 +86,6 @@ impl<T> DerefMut for Form<T> {
     }
 }
 
-#[async_trait::async_trait]
 impl<'a, T: DeserializeOwned> FromRequest<'a> for Form<T> {
     async fn from_request(req: &'a Request, body: &mut RequestBody) -> Result<Self> {
         if req.method() == Method::GET {

--- a/poem/src/web/json.rs
+++ b/poem/src/web/json.rs
@@ -103,7 +103,6 @@ impl<T> DerefMut for Json<T> {
     }
 }
 
-#[async_trait::async_trait]
 impl<'a, T: DeserializeOwned> FromRequest<'a> for Json<T> {
     async fn from_request(req: &'a Request, body: &mut RequestBody) -> Result<Self> {
         let content_type = req

--- a/poem/src/web/mod.rs
+++ b/poem/src/web/mod.rs
@@ -309,7 +309,7 @@ impl RequestBody {
 ///     .assert_status_is_ok();
 /// # });
 /// ```
-#[async_trait::async_trait]
+#[trait_make::make(Send)]
 pub trait FromRequest<'a>: Sized {
     /// Extract from request head and body.
     async fn from_request(req: &'a Request, body: &mut RequestBody) -> Result<Self>;
@@ -728,49 +728,42 @@ impl<T: Into<String> + Send> IntoResponse for Html<T> {
     }
 }
 
-#[async_trait::async_trait]
 impl<'a> FromRequest<'a> for &'a Request {
     async fn from_request(req: &'a Request, _body: &mut RequestBody) -> Result<Self> {
         Ok(req)
     }
 }
 
-#[async_trait::async_trait]
 impl<'a> FromRequest<'a> for &'a Uri {
     async fn from_request(req: &'a Request, _body: &mut RequestBody) -> Result<Self> {
         Ok(req.uri())
     }
 }
 
-#[async_trait::async_trait]
 impl<'a> FromRequest<'a> for Method {
     async fn from_request(req: &'a Request, _body: &mut RequestBody) -> Result<Self> {
         Ok(req.method().clone())
     }
 }
 
-#[async_trait::async_trait]
 impl<'a> FromRequest<'a> for Version {
     async fn from_request(req: &'a Request, _body: &mut RequestBody) -> Result<Self> {
         Ok(req.version())
     }
 }
 
-#[async_trait::async_trait]
 impl<'a> FromRequest<'a> for &'a HeaderMap {
     async fn from_request(req: &'a Request, _body: &mut RequestBody) -> Result<Self> {
         Ok(req.headers())
     }
 }
 
-#[async_trait::async_trait]
 impl<'a> FromRequest<'a> for Body {
     async fn from_request(_req: &'a Request, body: &mut RequestBody) -> Result<Self> {
         Ok(body.take()?)
     }
 }
 
-#[async_trait::async_trait]
 impl<'a> FromRequest<'a> for String {
     async fn from_request(_req: &'a Request, body: &mut RequestBody) -> Result<Self> {
         let data = body.take()?.into_bytes().await?;
@@ -778,42 +771,36 @@ impl<'a> FromRequest<'a> for String {
     }
 }
 
-#[async_trait::async_trait]
 impl<'a> FromRequest<'a> for Bytes {
     async fn from_request(_req: &'a Request, body: &mut RequestBody) -> Result<Self> {
         Ok(body.take()?.into_bytes().await?)
     }
 }
 
-#[async_trait::async_trait]
 impl<'a> FromRequest<'a> for Vec<u8> {
     async fn from_request(_req: &'a Request, body: &mut RequestBody) -> Result<Self> {
         Ok(body.take()?.into_vec().await?)
     }
 }
 
-#[async_trait::async_trait]
 impl<'a> FromRequest<'a> for &'a RemoteAddr {
     async fn from_request(req: &'a Request, _body: &mut RequestBody) -> Result<Self> {
         Ok(&req.state().remote_addr)
     }
 }
 
-#[async_trait::async_trait]
 impl<'a> FromRequest<'a> for &'a LocalAddr {
     async fn from_request(req: &'a Request, _body: &mut RequestBody) -> Result<Self> {
         Ok(&req.state().local_addr)
     }
 }
 
-#[async_trait::async_trait]
 impl<'a, T: FromRequest<'a>> FromRequest<'a> for Option<T> {
     async fn from_request(req: &'a Request, body: &mut RequestBody) -> Result<Self> {
         Ok(T::from_request(req, body).await.ok())
     }
 }
 
-#[async_trait::async_trait]
 impl<'a, T: FromRequest<'a>> FromRequest<'a> for Result<T> {
     async fn from_request(req: &'a Request, body: &mut RequestBody) -> Result<Self> {
         Ok(T::from_request(req, body).await)

--- a/poem/src/web/multipart.rs
+++ b/poem/src/web/multipart.rs
@@ -129,7 +129,6 @@ pub struct Multipart {
     inner: multer::Multipart<'static>,
 }
 
-#[async_trait::async_trait]
 impl<'a> FromRequest<'a> for Multipart {
     async fn from_request(req: &'a Request, body: &mut RequestBody) -> Result<Self> {
         let content_type = req

--- a/poem/src/web/path/mod.rs
+++ b/poem/src/web/path/mod.rs
@@ -125,7 +125,6 @@ impl<T: DeserializeOwned> Path<T> {
     }
 }
 
-#[async_trait::async_trait]
 impl<'a, T: DeserializeOwned> FromRequest<'a> for Path<T> {
     async fn from_request(req: &'a Request, _body: &mut RequestBody) -> Result<Self> {
         Self::internal_from_request(req).await.map_err(Into::into)

--- a/poem/src/web/query.rs
+++ b/poem/src/web/query.rs
@@ -70,7 +70,6 @@ impl<T: DeserializeOwned> Query<T> {
     }
 }
 
-#[async_trait::async_trait]
 impl<'a, T: DeserializeOwned> FromRequest<'a> for Query<T> {
     async fn from_request(req: &'a Request, _body: &mut RequestBody) -> Result<Self> {
         Self::internal_from_request(req).await.map_err(Into::into)

--- a/poem/src/web/real_ip.rs
+++ b/poem/src/web/real_ip.rs
@@ -8,7 +8,6 @@ use crate::{Addr, FromRequest, Request, RequestBody, Result};
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct RealIp(pub Option<IpAddr>);
 
-#[async_trait::async_trait]
 impl<'a> FromRequest<'a> for RealIp {
     async fn from_request(req: &'a Request, _body: &mut RequestBody) -> Result<Self> {
         if let Some(real_ip) = req

--- a/poem/src/web/static_file.rs
+++ b/poem/src/web/static_file.rs
@@ -101,7 +101,6 @@ pub struct StaticFileRequest {
     range: Option<Range>,
 }
 
-#[async_trait::async_trait]
 impl<'a> FromRequest<'a> for StaticFileRequest {
     async fn from_request(req: &'a Request, _body: &mut RequestBody) -> Result<Self> {
         Ok(Self {

--- a/poem/src/web/tempfile.rs
+++ b/poem/src/web/tempfile.rs
@@ -30,7 +30,6 @@ impl TempFile {
     }
 }
 
-#[async_trait::async_trait]
 impl<'a> FromRequest<'a> for TempFile {
     async fn from_request(_req: &'a Request, body: &mut RequestBody) -> Result<Self> {
         Self::internal_from_request(body).await.map_err(Into::into)

--- a/poem/src/web/typed_header.rs
+++ b/poem/src/web/typed_header.rs
@@ -65,7 +65,6 @@ impl<T: Header> TypedHeader<T> {
     }
 }
 
-#[async_trait::async_trait]
 impl<'a, T: Header> FromRequest<'a> for TypedHeader<T> {
     async fn from_request(req: &'a Request, _body: &mut RequestBody) -> Result<Self> {
         Self::internal_from_request(req).await.map_err(Into::into)

--- a/poem/src/web/websocket/extractor.rs
+++ b/poem/src/web/websocket/extractor.rs
@@ -66,7 +66,6 @@ impl WebSocket {
     }
 }
 
-#[async_trait::async_trait]
 impl<'a> FromRequest<'a> for WebSocket {
     async fn from_request(req: &'a Request, _body: &mut RequestBody) -> Result<Self> {
         Self::internal_from_request(req).await.map_err(Into::into)

--- a/poem/src/web/xml.rs
+++ b/poem/src/web/xml.rs
@@ -106,7 +106,6 @@ impl<T> DerefMut for Xml<T> {
     }
 }
 
-#[async_trait::async_trait]
 impl<'a, T: DeserializeOwned> FromRequest<'a> for Xml<T> {
     async fn from_request(req: &'a Request, body: &mut RequestBody) -> Result<Self> {
         let content_type = req

--- a/poem/src/web/yaml.rs
+++ b/poem/src/web/yaml.rs
@@ -107,7 +107,6 @@ impl<T> DerefMut for Yaml<T> {
     }
 }
 
-#[async_trait::async_trait]
 impl<'a, T: DeserializeOwned> FromRequest<'a> for Yaml<T> {
     async fn from_request(req: &'a Request, body: &mut RequestBody) -> Result<Self> {
         let content_type = req


### PR DESCRIPTION
An attempt to migrate poem to AFIT.

The current obstacle is there are some type errors come from trait object of `Future` and I don't know how to resolve it at present.

@sunli829 encouraged me to create this draft PR.

---

About the macro `trait-make`: it's a fork of [trait-variant](https://github.com/rust-lang/impl-trait-utils/tree/main/trait-variant) which can convert `async fn` in trait to `fn -> impl Future + Send` in place.