### PR TITLE
fix: graceful shutdown after switch to `hyper 1.x`

### DIFF
--- a/poem/src/server.rs
+++ b/poem/src/server.rs
@@ -360,7 +360,7 @@ async fn serve_connection(
     futures_util::pin_mut!(conn);
 
     tokio::select! {
-        _ = conn => {
+        _ = &mut conn => {
             // Connection completed successfully.
         },
         _ = connection_shutdown_token.cancelled() => {
@@ -368,4 +368,9 @@ async fn serve_connection(
         }
         _ = server_graceful_shutdown_token.cancelled() => {}
     }
+
+    // Init graceful shutdown for connection
+    conn.as_mut().graceful_shutdown();
+    // Continue awaiting after graceful-shutdown is initiated to handle existed requests.
+    let _ = conn.await;
 }


### PR DESCRIPTION
It was removed after switch to `hyper 1.x` ([commit](https://github.com/poem-web/poem/commit/0b6ca89be9636472b25f3677dc957fe098f72fab)) for some reason

Is there any reason? Because it seems to broke the logic (encountered issues after upgrade)

<details>
<summary> The changes affected the behavior </summary>

```patch
-    let mut conn = Http::new()
-        .serve_connection(socket, service)
-        .with_upgrades();
+    let builder = auto::Builder::new(hyper_util::rt::TokioExecutor::new());
+    let conn =
+        builder.serve_connection_with_upgrades(hyper_util::rt::TokioIo::new(socket), service);
+    futures_util::pin_mut!(conn);

     tokio::select! {
-        _ = &mut conn => {
+        _ = conn => {
             // Connection completed successfully.
             return;
         },
@@ -366,10 +368,4 @@
         }
         _ = server_graceful_shutdown_token.cancelled() => {}
     }
-
-    // Init graceful shutdown for connection (`GOAWAY` for `HTTP/2` or disabling `keep-alive` for `HTTP/1`)
-    Pin::new(&mut conn).graceful_shutdown();
-
-    // Continue awaiting after graceful-shutdown is initiated to handle existed requests.
-    let _ = conn.await;
```

</details>