### PR TITLE
update MSRV to 1.75.0 in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ license = "MIT OR Apache-2.0"
 documentation = "https://docs.rs/poem/"
 homepage = "https://github.com/poem-web/poem"
 repository = "https://github.com/poem-web/poem"
-rust-version = "1.74"
+rust-version = "1.75"
 
 [workspace.dependencies]
 poem = { path = "poem", version = "2.0.1", default-features = false }


### PR DESCRIPTION
Follow-up to ddfa81ea8323f0886a6f7212955d7504d4968083. Ran into this when trying to run tests on `master`.