### PR TITLE
update opentelemetry to v0.22.x

### DIFF
--- a/examples/poem/opentelemetry-jaeger/Cargo.toml
+++ b/examples/poem/opentelemetry-jaeger/Cargo.toml
@@ -8,10 +8,10 @@ publish.workspace = true
 poem = { workspace = true, features = ["opentelemetry"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tracing-subscriber.workspace = true
-opentelemetry = { version = "0.21.0", features = ["metrics"] }
-opentelemetry_sdk = { version = "0.21.0", features = ["rt-tokio"] }
-opentelemetry-http = { version = "0.10.0" }
-opentelemetry-otlp = { version = "0.14.0", features = [
+opentelemetry = { version = "0.22.0", features = ["metrics"] }
+opentelemetry_sdk = { version = "0.22.0", features = ["rt-tokio"] }
+opentelemetry-http = { version = "0.11.0" }
+opentelemetry-otlp = { version = "0.15.0", features = [
     "trace",
 ] }
 reqwest = "0.11"

--- a/poem/CHANGELOG.md
+++ b/poem/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - bump `nix` to 0.28
 - bump `redis` to 0.25
 - bump `reqwest` to 0.12
+- bump `opentelemetry` to 0.22  [#784](https://github.com/poem-web/poem/pull/784)
 
 # [2.0.1] 2024-03-04
 

--- a/poem/Cargo.toml
+++ b/poem/Cargo.toml
@@ -128,11 +128,11 @@ libcookie = { package = "cookie", version = "0.18", features = [
     "key-expansion",
     "secure",
 ], optional = true }
-opentelemetry-http = { version = "0.10.0", optional = true }
-opentelemetry-semantic-conventions = { version = "0.13.0", optional = true }
-opentelemetry-prometheus = { version = "0.14.0", optional = true }
+opentelemetry-http = { version = "0.11.0", optional = true }
+opentelemetry-semantic-conventions = { version = "0.14.0", optional = true }
+opentelemetry-prometheus = { version = "0.15.0", optional = true }
 libprometheus = { package = "prometheus", version = "0.13.0", optional = true }
-libopentelemetry = { package = "opentelemetry", version = "0.21.0", features = [
+libopentelemetry = { package = "opentelemetry", version = "0.22.0", features = [
     "metrics",
 ], optional = true }
 libtempfile = { package = "tempfile", version = "3.2.0", optional = true }

--- a/poem/src/middleware/opentelemetry_metrics.rs
+++ b/poem/src/middleware/opentelemetry_metrics.rs
@@ -3,7 +3,7 @@ use std::time::Instant;
 use libopentelemetry::{
     global,
     metrics::{Counter, Histogram, Unit},
-    Key,
+    Key, KeyValue,
 };
 use opentelemetry_semantic_conventions::trace;
 
@@ -74,8 +74,14 @@ impl<E: Endpoint> Endpoint for OpenTelemetryMetricsEndpoint<E> {
 
     async fn call(&self, req: Request) -> Result<Self::Output> {
         let mut labels = Vec::with_capacity(3);
-        labels.push(trace::HTTP_REQUEST_METHOD.string(req.method().to_string()));
-        labels.push(trace::URL_FULL.string(req.original_uri().to_string()));
+        labels.push(KeyValue::new(
+            trace::HTTP_REQUEST_METHOD,
+            req.method().to_string(),
+        ));
+        labels.push(KeyValue::new(
+            trace::URL_FULL,
+            req.original_uri().to_string(),
+        ));
 
         let s = Instant::now();
         let res = self.inner.call(req).await.map(IntoResponse::into_response);
@@ -85,20 +91,26 @@ impl<E: Endpoint> Endpoint for OpenTelemetryMetricsEndpoint<E> {
             Ok(resp) => {
                 if let Some(path_pattern) = resp.data::<PathPattern>() {
                     const HTTP_PATH_PATTERN: Key = Key::from_static_str("http.path_pattern");
-                    labels.push(HTTP_PATH_PATTERN.string(path_pattern.0.to_string()));
+                    labels.push(KeyValue::new(HTTP_PATH_PATTERN, path_pattern.0.to_string()));
                 }
 
-                labels.push(trace::HTTP_RESPONSE_STATUS_CODE.i64(resp.status().as_u16() as i64));
+                labels.push(KeyValue::new(
+                    trace::HTTP_RESPONSE_STATUS_CODE,
+                    resp.status().as_u16() as i64,
+                ));
             }
             Err(err) => {
                 if let Some(path_pattern) = err.data::<PathPattern>() {
                     const HTTP_PATH_PATTERN: Key = Key::from_static_str("http.path_pattern");
-                    labels.push(HTTP_PATH_PATTERN.string(path_pattern.0.to_string()));
+                    labels.push(KeyValue::new(HTTP_PATH_PATTERN, path_pattern.0.to_string()));
                 }
 
-                labels.push(trace::HTTP_RESPONSE_STATUS_CODE.i64(err.status().as_u16() as i64));
+                labels.push(KeyValue::new(
+                    trace::HTTP_RESPONSE_STATUS_CODE,
+                    err.status().as_u16() as i64,
+                ));
                 self.error_count.add(1, &labels);
-                labels.push(trace::EXCEPTION_MESSAGE.string(err.to_string()));
+                labels.push(KeyValue::new(trace::EXCEPTION_MESSAGE, err.to_string()));
             }
         }
 


### PR DESCRIPTION
Here's a PR to upgrade the OpenTelemetry dependencies to the 0.22 release series.

`opentelemetry-semantic-conventions` had [a breaking change](https://github.com/open-telemetry/opentelemetry-rust/blob/main/opentelemetry-semantic-conventions/CHANGELOG.md#v0140), so I had to make a few code changes in addition to bumping the crates.