### PR TITLE
refact: use `tokio::sync::Mutex` instead

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,3 @@
+disallowed-types = [
+    { path = "std::sync::Mutex", reason = "use tokio::sync::Mutex or parking_lot::Mutex" },
+]


### PR DESCRIPTION
a breaking change