### PR TITLE
RequestId Middleware

### DIFF
--- a/examples/poem/requestid/Cargo.toml
+++ b/examples/poem/requestid/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "example-requestid"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[dependencies]
+poem = { workspace = true, features = ["requestid"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+tracing-subscriber.workspace = true

--- a/examples/poem/requestid/src/main.rs
+++ b/examples/poem/requestid/src/main.rs
@@ -1,0 +1,35 @@
+use poem::{
+    get, handler,
+    listener::TcpListener,
+    middleware::{
+        ReqId, RequestId, ReuseId,
+        Tracing,
+    },
+    EndpointExt, Route,
+};
+
+#[handler]
+fn show_request_id(id: ReqId) -> ReqId {
+    id
+}
+
+#[tokio::main]
+async fn main() -> Result<(), std::io::Error> {
+    if std::env::var_os("RUST_LOG").is_none() {
+        std::env::set_var("RUST_LOG", "poem=debug");
+    }
+    tracing_subscriber::fmt::init();
+
+    let app = Route::new()
+        .at("/", get(show_request_id))
+        .with(Tracing)
+        // `RequestId` must be applied _after_ tracing, for the ID to be logged in the trace span
+        .with(RequestId::default().reuse_id(ReuseId::Use));
+
+    println!("example server listening on 127.0.0.1:8080");
+    println!("try `curl -v http://127.0.0.1:8080/`");
+    println!("try `curl -v -H 'x-request-id: 12345' http://127.0.0.1:8080/`");
+    poem::Server::new(TcpListener::bind("127.0.0.1:8080"))
+        .run(app)
+        .await
+}

--- a/poem/Cargo.toml
+++ b/poem/Cargo.toml
@@ -66,6 +66,7 @@ acme-base = [
 embed = ["rust-embed", "hex", "mime_guess"]
 xml = ["quick-xml"]
 yaml = ["serde_yaml"]
+requestid = ["dep:uuid"]
 
 [dependencies]
 poem-derive.workspace = true
@@ -162,6 +163,7 @@ tokio-stream = { workspace = true, optional = true }
 # Feature optional dependencies
 anyhow = { version = "1.0.0", optional = true }
 eyre06 = { package = "eyre", version = "0.6", optional = true }
+uuid = { version = "1.8.0", optional = true, default-features = false, features = ["v4"] }
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.28.0", features = ["fs", "user"] }

--- a/poem/src/middleware/mod.rs
+++ b/poem/src/middleware/mod.rs
@@ -16,6 +16,8 @@ mod opentelemetry_metrics;
 #[cfg(feature = "opentelemetry")]
 mod opentelemetry_tracing;
 mod propagate_header;
+#[cfg(feature = "requestid")]
+mod requestid;
 mod sensitive_header;
 mod set_header;
 mod size_limit;
@@ -35,6 +37,8 @@ pub use self::csrf::{Csrf, CsrfEndpoint};
 pub use self::opentelemetry_metrics::{OpenTelemetryMetrics, OpenTelemetryMetricsEndpoint};
 #[cfg(feature = "opentelemetry")]
 pub use self::opentelemetry_tracing::{OpenTelemetryTracing, OpenTelemetryTracingEndpoint};
+#[cfg(feature = "requestid")]
+pub use self::requestid::{ReqId, RequestId, RequestIdEndpoint, ReuseId};
 #[cfg(feature = "tokio-metrics")]
 pub use self::tokio_metrics_mw::{TokioMetrics, TokioMetricsEndpoint};
 #[cfg(feature = "tower-compat")]

--- a/poem/src/middleware/requestid.rs
+++ b/poem/src/middleware/requestid.rs
@@ -1,0 +1,234 @@
+use crate::{
+    http::StatusCode, Endpoint, Error, FromRequest, IntoResponse, Middleware, Request, Response,
+    Result,
+};
+use tracing::error;
+use tracing::{error_span, Instrument};
+use uuid::Uuid;
+
+const X_REQUEST_ID: &str = "x-request-id";
+
+/// Weather to use the request ID supplied in the request.
+#[derive(Clone, Copy, PartialEq, Eq, Default)]
+#[cfg_attr(docsrs, doc(cfg(feature = "requestid")))]
+pub enum ReuseId {
+    /// Use the incoming request ID.
+    Use,
+    /// Ignore the incoming request ID and generate a random ID.
+    #[default]
+    Ignore,
+}
+
+/// Middleware to add a unique ID to every incoming request.
+#[cfg_attr(docsrs, doc(cfg(feature = "requestid")))]
+pub struct RequestId {
+    header_name: String,
+    use_incoming_id: ReuseId,
+}
+
+impl RequestId {
+    /// Create a middleware that uses the `x-request-id` for the ID header.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Create a middleware that uses `header_name` for the ID header.
+    #[must_use]
+    pub fn with_header_name(header_name: impl AsRef<str>) -> Self {
+        Self {
+            header_name: header_name.as_ref().to_string(),
+            ..Default::default()
+        }
+    }
+
+    /// Configure weather to use the incoming ID.
+    #[must_use]
+    pub fn reuse_id(self, reuse_id: ReuseId) -> Self {
+        Self {
+            use_incoming_id: reuse_id,
+            ..self
+        }
+    }
+}
+
+impl Default for RequestId {
+    fn default() -> Self {
+        Self {
+            header_name: X_REQUEST_ID.to_string(),
+            use_incoming_id: ReuseId::default(),
+        }
+    }
+}
+
+impl<E: Endpoint> Middleware<E> for RequestId {
+    type Output = RequestIdEndpoint<E>;
+    fn transform(&self, next: E) -> Self::Output {
+        RequestIdEndpoint {
+            next,
+            header_name: self.header_name.clone(),
+            use_incoming_id: self.use_incoming_id,
+        }
+    }
+}
+
+/// Endpoint for `RequestId` middleware.
+#[cfg_attr(docsrs, doc(cfg(feature = "requestid")))]
+pub struct RequestIdEndpoint<E> {
+    next: E,
+    header_name: String,
+    use_incoming_id: ReuseId,
+}
+
+impl<E: Endpoint> Endpoint for RequestIdEndpoint<E> {
+    type Output = Response;
+
+    async fn call(&self, mut request: Request) -> Result<Self::Output> {
+        let request_id = if self.use_incoming_id == ReuseId::Use {
+            request
+                .header(&self.header_name)
+                .map_or_else(|| Uuid::new_v4().to_string(), ToString::to_string)
+        } else {
+            Uuid::new_v4().to_string()
+        };
+        request.set_data(ReqId(request_id.clone()));
+        let response = self.next.call(request);
+        let response = response.instrument(error_span!("", %request_id));
+        match response.await {
+            Ok(res) => Ok(res
+                .with_header(&self.header_name, request_id.to_string())
+                .into_response()),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+/// A request ID that can be extracted in handler functions.
+#[cfg_attr(docsrs, doc(cfg(feature = "requestid")))]
+#[derive(Clone)]
+pub struct ReqId(String);
+
+impl std::fmt::Display for ReqId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl<'a> FromRequest<'a> for ReqId {
+    async fn from_request(req: &'a Request, _: &mut crate::RequestBody) -> Result<Self> {
+        Ok(req
+            .extensions()
+            .get::<ReqId>()
+            .ok_or_else(|| {
+                error!("`RequestId` middleware is not active, while trying to extract `ReqId`!");
+                Error::from_string(
+                    "no associated request_id",
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                )
+            })?
+            .clone())
+    }
+}
+
+impl IntoResponse for ReqId {
+    fn into_response(self) -> Response {
+        self.to_string().into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{get, handler, test::TestClient, EndpointExt, Route};
+
+    #[handler(internal)]
+    fn reply_with_req_id(req_id: ReqId) -> ReqId {
+        req_id
+    }
+
+    fn app(middleware: RequestId) -> impl Endpoint {
+        Route::new()
+            .at("/", get(reply_with_req_id))
+            .with(middleware)
+    }
+
+    #[tokio::test]
+    async fn x_request_id_header_is_present() {
+        let app = app(RequestId::default());
+        let cli = TestClient::new(app);
+        let response = cli.get("/").send().await;
+
+        response.assert_header_exist(X_REQUEST_ID);
+        response.assert_status_is_ok();
+    }
+
+    #[tokio::test]
+    async fn extracted_id_matches_header() {
+        let app = app(RequestId::default());
+        let cli = TestClient::new(app);
+        let response = cli.get("/").send().await;
+        let header_value = response.0.header(X_REQUEST_ID).unwrap().to_string();
+        let body_value = response.0.into_body().into_string().await.unwrap();
+
+        assert_eq!(header_value, body_value);
+    }
+
+    #[tokio::test]
+    async fn custom_header() {
+        let header_name = "y-request-id";
+        let app = app(RequestId::with_header_name(header_name));
+        let cli = TestClient::new(app);
+        let mut response = cli.get("/").send().await;
+        let header_value = response.0.header(header_name).unwrap().to_string();
+        let body_value = response.0.take_body().into_string().await.unwrap();
+
+        response.assert_header_exist(header_name);
+        assert_eq!(header_value, body_value);
+    }
+
+    #[tokio::test]
+    async fn use_incoming_id() {
+        let id = "foobar";
+        let app = app(RequestId::default().reuse_id(ReuseId::Use));
+        let cli = TestClient::new(app);
+        let response = cli.get("/").header(X_REQUEST_ID, id).send().await;
+
+        response.assert_header_exist(X_REQUEST_ID);
+        assert_eq!(response.0.header(X_REQUEST_ID), Some(id));
+    }
+
+    #[tokio::test]
+    async fn ignore_incoming_id() {
+        let id = "foobar";
+        let app = app(RequestId::default().reuse_id(ReuseId::Ignore));
+        let cli = TestClient::new(app);
+        let response = cli.get("/").header(X_REQUEST_ID, id).send().await;
+
+        response.assert_header_exist(X_REQUEST_ID);
+        assert_ne!(response.0.header(X_REQUEST_ID), Some(id));
+    }
+
+    #[tokio::test]
+    async fn use_incoming_id_different_header() {
+        let header_name = "y-request-id";
+        let id = "foobar";
+        let app = app(RequestId::with_header_name(header_name).reuse_id(ReuseId::Use));
+        let cli = TestClient::new(app);
+        let response = cli.get("/").header(header_name, id).send().await;
+
+        response.assert_header_exist(header_name);
+        assert_eq!(response.0.header(header_name), Some(id));
+    }
+
+    #[tokio::test]
+    async fn ignore_incoming_id_different_header() {
+        let header_name = "y-request-id";
+        let id = "foobar";
+        let app = app(RequestId::with_header_name(header_name).reuse_id(ReuseId::Ignore));
+        let cli = TestClient::new(app);
+        let response = cli.get("/").header(header_name, id).send().await;
+
+        response.assert_header_exist(header_name);
+        assert_ne!(response.0.header(header_name), Some(id));
+    }
+}

--- a/poem/src/middleware/tracing_mw.rs
+++ b/poem/src/middleware/tracing_mw.rs
@@ -35,6 +35,7 @@ impl<E: Endpoint> Endpoint for TracingEndpoint<E> {
             .map(|addr| addr.to_string())
             .unwrap_or_else(|| req.remote_addr().to_string());
 
+        #[cfg(not(feature = "requestid"))]
         let span = tracing::span!(
             target: module_path!(),
             Level::INFO,
@@ -44,6 +45,36 @@ impl<E: Endpoint> Endpoint for TracingEndpoint<E> {
             method = %req.method(),
             uri = %req.original_uri(),
         );
+        #[cfg(feature = "requestid")]
+        let span = {
+            req.extensions()
+                .get::<crate::middleware::requestid::ReqId>()
+                .map_or_else(
+                    || {
+                        tracing::span!(
+                            target: module_path!(),
+                            Level::INFO,
+                            "request",
+                            remote_addr = %remote_addr,
+                            version = ?req.version(),
+                            method = %req.method(),
+                            uri = %req.original_uri(),
+                        )
+                    },
+                    |request_id| {
+                        tracing::span!(
+                            target: module_path!(),
+                            Level::INFO,
+                            "request",
+                            remote_addr = %remote_addr,
+                            version = ?req.version(),
+                            method = %req.method(),
+                            uri = %req.original_uri(),
+                            %request_id
+                        )
+                    },
+                )
+        };
 
         if let Some(path_pattern) = req.data::<PathPattern>() {
             span.record("path_pattern", path_pattern.0.as_ref());


### PR DESCRIPTION
This PR introduces a feature-gated `RequestId` middleware that associates an unique ID with each incoming request. `ReqId` can be extracted in request handlers and returned as a response (e.g. for error pages). Each response contains a header with the ID (default name: `x-request-id` but the header name is configurable).

The `Tracing` middleware was made aware of the request ID and adds it to the request span (for this to work, the order of the middlewares is important. `Tracing` must be applied _before_ `RequestId`.

If `ReuseId::Use` is set, the middleware will propagate the request ID from an incoming request. If the request contained an `x-request-id` header (or whatever header name is configured), this value will be used.