### PR TITLE
 fix: poem-openapi: support u128 & i128

### DIFF
--- a/poem-openapi/src/types/external/integers.rs
+++ b/poem-openapi/src/types/external/integers.rs
@@ -212,7 +212,13 @@ macro_rules! impl_type_for_unsigneds {
     };
 }
 
-impl_type_for_integers!((i8, "int8"), (i16, "int16"), (i32, "int32"), (i64, "int64"));
+impl_type_for_integers!(
+    (i8, "int8"),
+    (i16, "int16"),
+    (i32, "int32"),
+    (i64, "int64"),
+    (i128, "int128")
+);
 
 impl_type_for_unsigneds!(
     (u8, "uint8"),

--- a/poem-openapi/src/types/external/integers.rs
+++ b/poem-openapi/src/types/external/integers.rs
@@ -219,5 +219,6 @@ impl_type_for_unsigneds!(
     (u16, "uint16"),
     (u32, "uint32"),
     (u64, "uint64"),
+    (u128, "uint128"),
     (usize, "uint64")
 );


### PR DESCRIPTION
Add u128 to poem-openapi external types impl_type_for_unsigneds usage
Add i128 to poem-openapi external types impl_type_for_integers usage

