### PR TITLE
Expose Poem-OpenApi Upload File struct

### DIFF
--- a/poem-openapi/src/types/multipart/upload.rs
+++ b/poem-openapi/src/types/multipart/upload.rs
@@ -79,7 +79,7 @@ impl Upload {
     }
 
     /// Consumes this body object to return the file.
-    pub fn get_file(self) -> File {
+    pub fn into_file(self) -> File {
         self.file
     }
 }

--- a/poem-openapi/src/types/multipart/upload.rs
+++ b/poem-openapi/src/types/multipart/upload.rs
@@ -77,7 +77,7 @@ impl Upload {
     pub fn into_async_read(self) -> impl AsyncRead + Unpin + Send + 'static {
         self.file
     }
-    
+
     /// Consumes this body object to return the file.
     pub fn get_file(self) -> File {
         self.file

--- a/poem-openapi/src/types/multipart/upload.rs
+++ b/poem-openapi/src/types/multipart/upload.rs
@@ -77,6 +77,11 @@ impl Upload {
     pub fn into_async_read(self) -> impl AsyncRead + Unpin + Send + 'static {
         self.file
     }
+    
+    /// Consumes this body object to return the file.
+    pub fn get_file(self) -> File {
+        self.file
+    }
 }
 
 impl Type for Upload {


### PR DESCRIPTION
Some crates, including the (Amazon S3 Crate)[https://docs.rs/aws-sdk-s3/latest/aws_sdk_s3/], expect the `File` struct directly, instead of the `impl AsyncRead`. This PR exposes this `File` struct through a getter function.