### PR TITLE
update opentelemetry to v0.23.x

### DIFF
--- a/examples/poem/opentelemetry-jaeger/Cargo.toml
+++ b/examples/poem/opentelemetry-jaeger/Cargo.toml
@@ -8,10 +8,10 @@ publish.workspace = true
 poem = { workspace = true, features = ["opentelemetry"] }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tracing-subscriber.workspace = true
-opentelemetry = { version = "0.22.0", features = ["metrics"] }
-opentelemetry_sdk = { version = "0.22.0", features = ["rt-tokio"] }
-opentelemetry-http = { version = "0.11.0" }
-opentelemetry-otlp = { version = "0.15.0", features = [
+opentelemetry = { version = "0.23.0", features = ["metrics"] }
+opentelemetry_sdk = { version = "0.23.0", features = ["rt-tokio"] }
+opentelemetry-http = { version = "0.12.0" }
+opentelemetry-otlp = { version = "0.16.0", features = [
     "trace",
 ] }
 reqwest = "0.11"

--- a/poem/CHANGELOG.md
+++ b/poem/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [unreleased]
+
+- bump `opentelemetry` to `0.23`
+
 # [3.0.1] 2024-05-18
 
 - Fix error response builder, missing Content-Type header [#808](https://github.com/poem-web/poem/pull/808)

--- a/poem/Cargo.toml
+++ b/poem/Cargo.toml
@@ -128,11 +128,11 @@ libcookie = { package = "cookie", version = "0.18", features = [
     "key-expansion",
     "secure",
 ], optional = true }
-opentelemetry-http = { version = "0.11.0", optional = true }
-opentelemetry-semantic-conventions = { version = "0.14.0", optional = true }
-opentelemetry-prometheus = { version = "0.15.0", optional = true }
+opentelemetry-http = { version = "0.12.0", optional = true }
+opentelemetry-semantic-conventions = { version = "0.15.0", optional = true }
+opentelemetry-prometheus = { version = "0.16.0", optional = true }
 libprometheus = { package = "prometheus", version = "0.13.0", optional = true }
-libopentelemetry = { package = "opentelemetry", version = "0.22.0", features = [
+libopentelemetry = { package = "opentelemetry", version = "0.23.0", features = [
     "metrics",
 ], optional = true }
 libtempfile = { package = "tempfile", version = "3.2.0", optional = true }


### PR DESCRIPTION
Here's a PR to upgrade the [OpenTelemetry dependencies](https://github.com/open-telemetry/opentelemetry-rust) to the 0.23 release series. The breaking changes do not seem to affect Poem this time.