### PR TITLE
fix(prometheus): use correct `content-type` header

### DIFF
--- a/poem/src/endpoint/prometheus_exporter.rs
+++ b/poem/src/endpoint/prometheus_exporter.rs
@@ -65,9 +65,8 @@ impl Endpoint for PrometheusExporterEndpoint {
 
 #[cfg(test)]
 mod tests {
-    use crate::test::TestClient;
-
     use super::*;
+    use crate::test::TestClient;
 
     #[tokio::test]
     async fn test_content_type() {

--- a/poem/src/endpoint/prometheus_exporter.rs
+++ b/poem/src/endpoint/prometheus_exporter.rs
@@ -62,3 +62,20 @@ impl Endpoint for PrometheusExporterEndpoint {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::test::TestClient;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_content_type() {
+        let client = TestClient::new(PrometheusExporter::new(Registry::new()));
+
+        let resp = client.get("/metrics").send().await;
+
+        resp.assert_status_is_ok();
+        resp.assert_content_type("text/plain; version=0.0.4");
+    }
+}

--- a/poem/src/endpoint/prometheus_exporter.rs
+++ b/poem/src/endpoint/prometheus_exporter.rs
@@ -55,7 +55,9 @@ impl Endpoint for PrometheusExporterEndpoint {
         let metric_families = self.registry.gather();
         let mut result = Vec::new();
         match encoder.encode(&metric_families, &mut result) {
-            Ok(()) => Ok(Response::builder().content_type("text/plain").body(result)),
+            Ok(()) => Ok(Response::builder()
+                .content_type(encoder.format_type())
+                .body(result)),
             Err(_) => Err(StatusCode::INTERNAL_SERVER_ERROR.into()),
         }
     }


### PR DESCRIPTION
The header should include the version.

https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format

https://docs.rs/prometheus/0.13.4/src/prometheus/encoder/text.rs.html#12-13