### PR TITLE
fix read_only_with_default test when only default features are enabled

### DIFF
--- a/poem-openapi/tests/object.rs
+++ b/poem-openapi/tests/object.rs
@@ -4,7 +4,6 @@ use poem_openapi::{
     Enum, NewType, Object, OpenApi,
 };
 use serde_json::json;
-use time::OffsetDateTime;
 
 fn get_meta<T: Type>() -> MetaSchema {
     let mut registry = Registry::new();
@@ -390,8 +389,10 @@ fn read_only() {
     );
 }
 
+#[cfg(feature = "time")]
 #[test]
 fn read_only_with_default() {
+    use time::OffsetDateTime;
     fn default_offset_datetime() -> OffsetDateTime {
         OffsetDateTime::from_unix_timestamp(1694045893).unwrap()
     }


### PR DESCRIPTION
When only the default features are enabled, `poem-openapi/tests/object.rs` cannot be built, as it depends on the `time`  crate, which is optional.
Adding `#[cfg(feature = "time")]` to the `read_only_with_default` test and moving `use time::OffsetDateTime;` into the test function body resolves the issue.

With out this PR, `cargo test -r` produces:
```
...
error[E0432]: unresolved import `time`
 --> poem-openapi/tests/object.rs:7:5
  |
7 | use time::OffsetDateTime;
  |     ^^^^ help: a similar path exists: `tokio::time`

error[E0599]: the method `unwrap` exists for enum `Result<Obj, ParseError<Obj>>`, but its trait bounds were not satisfied
   --> poem-openapi/tests/object.rs:411:59
    |
400 |     struct Obj {
    |     ---------- doesn't satisfy `read_only_with_default::Obj: Sized`
...
411 |         Obj::parse_from_json(Some(serde_json::json!({}))).unwrap(),
    |                                                           ^^^^^^ method cannot be called on `Result<Obj, ParseError<Obj>>` due to unsatisfied trait bounds
    |
    = note: the following trait bounds were not satisfied:
            `{type error}: Sized`
            which is required by `read_only_with_default::Obj: Sized`
...
```