### PR TITLE
Implemented nullable fields for openapi spec generation

### DIFF
--- a/poem-openapi-derive/src/object.rs
+++ b/poem-openapi-derive/src/object.rs
@@ -31,6 +31,8 @@ struct ObjectField {
     #[darling(default)]
     write_only: bool,
     #[darling(default)]
+    nullable: bool,
+    #[darling(default)]
     read_only: bool,
     #[darling(default)]
     validator: Option<Validators>,
@@ -68,6 +70,8 @@ struct ObjectArgs {
     read_only_all: bool,
     #[darling(default)]
     write_only_all: bool,
+    #[darling(default)]
+    nullable_all: bool,
     #[darling(default)]
     deny_unknown_fields: bool,
     #[darling(default)]
@@ -115,6 +119,7 @@ pub(crate) fn generate(args: DeriveInput) -> GeneratorResult<TokenStream> {
         let field_ty = &field.ty;
         let read_only = args.read_only_all || field.read_only;
         let write_only = args.write_only_all || field.write_only;
+        let nullable = args.nullable_all || field.nullable;
         let skip_serializing_if_is_none =
             field.skip_serializing_if_is_none || args.skip_serializing_if_is_none;
         let skip_serializing_if_is_empty =
@@ -287,6 +292,7 @@ pub(crate) fn generate(args: DeriveInput) -> GeneratorResult<TokenStream> {
                 let patch_schema = {
                     let mut schema = #crate_name::registry::MetaSchema::ANY;
                     schema.default = #field_meta_default;
+                    schema.nullable = #nullable;
                     schema.read_only = #read_only;
                     schema.write_only = #write_only;
 

--- a/poem-openapi/src/registry/mod.rs
+++ b/poem-openapi/src/registry/mod.rs
@@ -75,6 +75,8 @@ pub struct MetaSchema {
     pub enum_items: Vec<Value>,
     #[serde(skip_serializing_if = "is_false")]
     pub deprecated: bool,
+    #[serde(skip_serializing_if = "is_false")]
+    pub nullable: bool,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub any_of: Vec<MetaSchemaRef>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -150,6 +152,7 @@ impl MetaSchema {
         discriminator: None,
         read_only: false,
         write_only: false,
+        nullable: false,
         example: None,
         multiple_of: None,
         maximum: None,
@@ -189,6 +192,7 @@ impl MetaSchema {
             default,
             read_only,
             write_only,
+            nullable,
             title,
             description,
             external_docs,
@@ -213,6 +217,7 @@ impl MetaSchema {
     ) -> Self {
         self.read_only |= read_only;
         self.write_only |= write_only;
+        self.nullable |= nullable;
 
         macro_rules! merge_optional {
             ($($name:ident),*) => {

--- a/poem-openapi/src/registry/mod.rs
+++ b/poem-openapi/src/registry/mod.rs
@@ -338,9 +338,9 @@ impl MetaSchemaRef {
                     MetaSchemaRef::Inline(Box::new(MetaSchema {
                         all_of: vec![
                             MetaSchemaRef::Reference(name),
-                            MetaSchemaRef::Inline(Box::new(other)),
+                            MetaSchemaRef::Inline(Box::new(other.clone())),
                         ],
-                        ..MetaSchema::ANY
+                        ..other
                     }))
                 }
             }


### PR DESCRIPTION
I've added the ability to set nullable fields on a struct with poem_api::Object derive.

Following the spec here: https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.0.md#fixed-fields-20

Either for each individual field, with `nullable` attibute, or at the struct level with `nullable_all`.

It also solves this opened issue: https://github.com/poem-web/poem/issues/701