### PR TITLE
Grammatical fixes in middleware docstrings

### DIFF
--- a/poem/src/middleware/add_data.rs
+++ b/poem/src/middleware/add_data.rs
@@ -1,6 +1,6 @@
 use crate::{Endpoint, Middleware, Request, Result};
 
-/// Middleware for add any data to request.
+/// Middleware for adding any data to a request.
 pub struct AddData<T> {
     value: T,
 }
@@ -27,7 +27,7 @@ where
     }
 }
 
-/// Endpoint for AddData middleware.
+/// Endpoint for the AddData middleware.
 pub struct AddDataEndpoint<E, T> {
     inner: E,
     value: T,

--- a/poem/src/middleware/catch_panic.rs
+++ b/poem/src/middleware/catch_panic.rs
@@ -34,7 +34,7 @@ where
     }
 }
 
-/// Middleware for catches panics and converts them into `500 INTERNAL SERVER
+/// Middleware that catches panics and converts them into `500 INTERNAL SERVER
 /// ERROR` responses.
 ///
 /// # Example
@@ -122,7 +122,7 @@ impl<E: Endpoint, H: PanicHandler> Middleware<E> for CatchPanic<H> {
     }
 }
 
-/// Endpoint for `PanicHandler` middleware.
+/// Endpoint for the `PanicHandler` middleware.
 pub struct CatchPanicEndpoint<E, H> {
     inner: E,
     panic_handler: H,

--- a/poem/src/middleware/compression.rs
+++ b/poem/src/middleware/compression.rs
@@ -68,11 +68,10 @@ fn parse_accept_encoding(
         .map(|(coding, _)| coding)
 }
 
-/// Middleware for decompress request body and compress response body.
+/// Middleware to decompress the request body and compress the response body.
 ///
-/// It selects the decompression algorithm according to the request
-/// `Content-Encoding` header, and selects the compression algorithm according
-/// to the request `Accept-Encoding` header.
+/// The decompression algorithm is selected according to the request `Content-Encoding` header,
+/// and the compression algorithm is selected according to the request `Accept-Encoding` header.
 #[cfg_attr(docsrs, doc(cfg(feature = "compression")))]
 #[derive(Default)]
 pub struct Compression {
@@ -97,7 +96,7 @@ impl Compression {
         }
     }
 
-    /// Specify the enabled algorithms (default to all)
+    /// Specify the enabled algorithms (defaults to all)
     #[must_use]
     #[inline]
     pub fn algorithms(self, algorithms: impl IntoIterator<Item = CompressionAlgo>) -> Self {
@@ -120,7 +119,7 @@ impl<E: Endpoint> Middleware<E> for Compression {
     }
 }
 
-/// Endpoint for Compression middleware.
+/// Endpoint for the Compression middleware.
 #[cfg_attr(docsrs, doc(cfg(feature = "compression")))]
 pub struct CompressionEndpoint<E: Endpoint> {
     ep: E,

--- a/poem/src/middleware/cookie_jar_manager.rs
+++ b/poem/src/middleware/cookie_jar_manager.rs
@@ -42,7 +42,7 @@ where
     }
 }
 
-/// Endpoint for `CookieJarManager` middleware.
+/// Endpoint for the `CookieJarManager` middleware.
 #[cfg_attr(docsrs, doc(cfg(feature = "cookie")))]
 pub struct CookieJarManagerEndpoint<E> {
     inner: E,

--- a/poem/src/middleware/cors.rs
+++ b/poem/src/middleware/cors.rs
@@ -58,7 +58,7 @@ impl Cors {
         }
     }
 
-    /// Set allow credentials.
+    /// Set the allow credentials.
     #[must_use]
     pub fn allow_credentials(mut self, allow_credentials: bool) -> Self {
         self.allow_credentials = allow_credentials;
@@ -67,7 +67,7 @@ impl Cors {
 
     /// Add an allow header.
     ///
-    /// NOTE: Default is allow any header.
+    /// NOTE: The default is to allow any header.
     #[must_use]
     pub fn allow_header<T>(mut self, header: T) -> Self
     where
@@ -95,7 +95,7 @@ impl Cors {
 
     /// Add an allow method.
     ///
-    /// NOTE: Default is allow any method.
+    /// NOTE: The default is to allow any method.
     #[must_use]
     pub fn allow_method<T>(mut self, method: T) -> Self
     where
@@ -123,7 +123,7 @@ impl Cors {
 
     /// Add an allow origin.
     ///
-    /// NOTE: Default is allow any origin.
+    /// NOTE: The default is to allow any origin.
     #[must_use]
     pub fn allow_origin<T>(mut self, origin: T) -> Self
     where

--- a/poem/src/middleware/csrf.rs
+++ b/poem/src/middleware/csrf.rs
@@ -119,7 +119,7 @@ impl Csrf {
         Self { key, ..self }
     }
 
-    /// Sets the `Secure` to the csrf cookie. Default is `true`.
+    /// Sets, whether `Secure` is set for the csrf cookie. Defaults to `true`.
     #[must_use]
     pub fn secure(self, value: bool) -> Self {
         Self {
@@ -128,7 +128,7 @@ impl Csrf {
         }
     }
 
-    /// Sets the `HttpOnly` to the csrf cookie. Default is `true`.
+    /// Sets, whether `HttpOnly` is set for the csrf cookie. Defaults to `true`.
     #[must_use]
     pub fn http_only(self, value: bool) -> Self {
         Self {
@@ -137,7 +137,7 @@ impl Csrf {
         }
     }
 
-    /// Sets the `SameSite` to the csrf cookie. Default is
+    /// Sets, whether `SameSite` is set for the csrf cookie. Defaults to `true`.
     /// [`SameSite::Strict`](libcookie::SameSite::Strict).
     #[must_use]
     pub fn same_site(self, value: impl Into<Option<SameSite>>) -> Self {
@@ -174,7 +174,7 @@ impl<E: Endpoint> Middleware<E> for Csrf {
     }
 }
 
-/// Endpoint for Csrf middleware.
+/// Endpoint for the Csrf middleware.
 #[cfg_attr(docsrs, doc(cfg(feature = "csrf")))]
 pub struct CsrfEndpoint<E> {
     inner: E,

--- a/poem/src/middleware/force_https.rs
+++ b/poem/src/middleware/force_https.rs
@@ -6,7 +6,7 @@ use crate::{web::Redirect, Endpoint, IntoResponse, Middleware, Request, Response
 
 type FilterFn = Arc<dyn Fn(&Request) -> bool + Send + Sync>;
 
-/// Middleware for force redirect to HTTPS uri.
+/// Middleware which forces redirects to a HTTPS uri.
 #[derive(Default)]
 pub struct ForceHttps {
     https_port: Option<u16>,
@@ -14,12 +14,12 @@ pub struct ForceHttps {
 }
 
 impl ForceHttps {
-    /// Create new `ForceHttps` middleware.
+    /// Create a new `ForceHttps` middleware.
     pub fn new() -> Self {
         Default::default()
     }
 
-    /// Specify https port.
+    /// Specify the https port.
     #[must_use]
     pub fn https_port(self, port: u16) -> Self {
         Self {
@@ -53,7 +53,7 @@ where
     }
 }
 
-/// Endpoint for ForceHttps middleware.
+/// Endpoint for the ForceHttps middleware.
 pub struct ForceHttpsEndpoint<E> {
     inner: E,
     https_port: Option<u16>,

--- a/poem/src/middleware/mod.rs
+++ b/poem/src/middleware/mod.rs
@@ -59,14 +59,14 @@ use crate::endpoint::Endpoint;
 
 /// Represents a middleware trait.
 ///
-/// # Create you own middleware
+/// # Create your own middleware
 ///
 /// ```
 /// use poem::{
 ///     handler, test::TestClient, web::Data, Endpoint, EndpointExt, Middleware, Request, Result,
 /// };
 ///
-/// /// A middleware that extract token from HTTP headers.
+/// /// A middleware that extracts token from HTTP headers.
 /// struct TokenMiddleware;
 ///
 /// impl<E: Endpoint> Middleware<E> for TokenMiddleware {

--- a/poem/src/middleware/normalize_path.rs
+++ b/poem/src/middleware/normalize_path.rs
@@ -71,7 +71,7 @@ impl<E: Endpoint> Middleware<E> for NormalizePath {
     }
 }
 
-/// Endpoint for NormalizePath middleware.
+/// Endpoint for the NormalizePath middleware.
 pub struct NormalizePathEndpoint<E> {
     inner: E,
     merge_slash: Regex,

--- a/poem/src/middleware/opentelemetry_metrics.rs
+++ b/poem/src/middleware/opentelemetry_metrics.rs
@@ -60,7 +60,7 @@ impl<E: Endpoint> Middleware<E> for OpenTelemetryMetrics {
     }
 }
 
-/// Endpoint for OpenTelemetryMetrics middleware.
+/// Endpoint for the OpenTelemetryMetrics middleware.
 #[cfg_attr(docsrs, doc(cfg(feature = "opentelemetry")))]
 pub struct OpenTelemetryMetricsEndpoint<E> {
     request_count: Counter<u64>,

--- a/poem/src/middleware/opentelemetry_tracing.rs
+++ b/poem/src/middleware/opentelemetry_tracing.rs
@@ -45,7 +45,7 @@ where
     }
 }
 
-/// Endpoint for `OpenTelemetryTracing` middleware.
+/// Endpoint for the `OpenTelemetryTracing` middleware.
 #[cfg_attr(docsrs, doc(cfg(feature = "opentelemetry")))]
 pub struct OpenTelemetryTracingEndpoint<T, E> {
     tracer: Arc<T>,

--- a/poem/src/middleware/propagate_header.rs
+++ b/poem/src/middleware/propagate_header.rs
@@ -4,7 +4,7 @@ use http::{header::HeaderName, HeaderMap};
 
 use crate::{Endpoint, IntoResponse, Middleware, Request, Response, Result};
 
-/// Middleware for propagate a header from the request to the response.
+/// Middleware to propagate a header from the request to the response.
 #[derive(Default)]
 pub struct PropagateHeader {
     headers: HashSet<HeaderName>,
@@ -41,7 +41,7 @@ impl<E: Endpoint> Middleware<E> for PropagateHeader {
     }
 }
 
-/// Endpoint for PropagateHeader middleware.
+/// Endpoint for the PropagateHeader middleware.
 pub struct PropagateHeaderEndpoint<E> {
     inner: E,
     headers: HashSet<HeaderName>,

--- a/poem/src/middleware/requestid.rs
+++ b/poem/src/middleware/requestid.rs
@@ -8,7 +8,7 @@ use crate::{
 
 const X_REQUEST_ID: &str = "x-request-id";
 
-/// Weather to use the request ID supplied in the request.
+/// Whether to use the request ID supplied in the request.
 #[derive(Clone, Copy, PartialEq, Eq, Default)]
 #[cfg_attr(docsrs, doc(cfg(feature = "requestid")))]
 pub enum ReuseId {
@@ -42,7 +42,7 @@ impl RequestId {
         }
     }
 
-    /// Configure weather to use the incoming ID.
+    /// Configure whether to use the incoming ID.
     #[must_use]
     pub fn reuse_id(self, reuse_id: ReuseId) -> Self {
         Self {
@@ -72,7 +72,7 @@ impl<E: Endpoint> Middleware<E> for RequestId {
     }
 }
 
-/// Endpoint for `RequestId` middleware.
+/// Endpoint for the `RequestId` middleware.
 #[cfg_attr(docsrs, doc(cfg(feature = "requestid")))]
 pub struct RequestIdEndpoint<E> {
     next: E,
@@ -103,7 +103,7 @@ impl<E: Endpoint> Endpoint for RequestIdEndpoint<E> {
     }
 }
 
-/// A request ID that can be extracted in handler functions.
+/// A request ID which can be extracted in handler functions.
 #[cfg_attr(docsrs, doc(cfg(feature = "requestid")))]
 #[derive(Clone)]
 pub struct ReqId(String);

--- a/poem/src/middleware/sensitive_header.rs
+++ b/poem/src/middleware/sensitive_header.rs
@@ -12,7 +12,7 @@ enum AppliedTo {
     Both,
 }
 
-/// Middleware for mark headers value represents sensitive information.
+/// Middleware to mark that a headers' value represents sensitive information.
 ///
 /// Sensitive data could represent passwords or other data that should not be
 /// stored on disk or in memory. By marking header values as sensitive,
@@ -84,7 +84,7 @@ impl<E: Endpoint> Middleware<E> for SensitiveHeader {
     }
 }
 
-/// Endpoint for SensitiveHeader middleware.
+/// Endpoint for the SensitiveHeader middleware.
 pub struct SensitiveHeaderEndpoint<E> {
     inner: E,
     headers: HashSet<HeaderName>,

--- a/poem/src/middleware/set_header.rs
+++ b/poem/src/middleware/set_header.rs
@@ -9,7 +9,7 @@ enum Action {
     Append(HeaderName, HeaderValue),
 }
 
-/// Middleware for override/append headers to response.
+/// Middleware to override or append headers to a response.
 ///
 /// # Example
 ///
@@ -54,10 +54,10 @@ impl SetHeader {
         Default::default()
     }
 
-    /// Inserts a header to response.
+    /// Inserts a header into the response.
     ///
-    /// If a previous value exists for the same header, it is
-    /// removed and replaced with the new header value.
+    /// If a previous value exists for the same header, it will
+    /// be overridden.
     #[must_use]
     pub fn overriding<K, V>(mut self, key: K, value: V) -> Self
     where
@@ -72,7 +72,7 @@ impl SetHeader {
         self
     }
 
-    /// Appends a header to response.
+    /// Appends a header to the response.
     ///
     /// If previous values exist, the header will have multiple values.
     #[must_use]
@@ -101,7 +101,7 @@ impl<E: Endpoint> Middleware<E> for SetHeader {
     }
 }
 
-/// Endpoint for SetHeader middleware.
+/// Endpoint for the SetHeader middleware.
 pub struct SetHeaderEndpoint<E> {
     inner: E,
     actions: Vec<Action>,

--- a/poem/src/middleware/size_limit.rs
+++ b/poem/src/middleware/size_limit.rs
@@ -2,10 +2,10 @@ use crate::{
     error::SizedLimitError, web::headers::HeaderMapExt, Endpoint, Middleware, Request, Result,
 };
 
-/// Middleware for limit the request payload size.
+/// Middleware to limit the request payload size.
 ///
-/// If the incoming request does not contain the `Content-Length` header, it
-/// will return `LENGTH_REQUIRED` status code.
+/// If the incoming request does not contain the `Content-Length` header, the
+/// middleware will return the `LENGTH_REQUIRED` status code.
 ///
 /// # Errors
 ///
@@ -32,7 +32,7 @@ impl<E: Endpoint> Middleware<E> for SizeLimit {
     }
 }
 
-/// Endpoint for SizeLimit middleware.
+/// Endpoint for the SizeLimit middleware.
 pub struct SizeLimitEndpoint<E> {
     inner: E,
     max_size: usize,

--- a/poem/src/middleware/tokio_metrics_mw.rs
+++ b/poem/src/middleware/tokio_metrics_mw.rs
@@ -71,7 +71,7 @@ impl<E: Endpoint> Middleware<E> for TokioMetrics {
     }
 }
 
-/// Endpoint for TokioMetrics middleware.
+/// Endpoint for the TokioMetrics middleware.
 pub struct TokioMetricsEndpoint<E> {
     inner: E,
     monitor: TaskMonitor,

--- a/poem/src/middleware/tower_compat.rs
+++ b/poem/src/middleware/tower_compat.rs
@@ -57,7 +57,7 @@ where
     }
 }
 
-/// An endpoint to tower service adapter.
+/// An endpoint to the tower service adapter.
 pub struct EndpointToTowerService<E>(Arc<E>);
 
 impl<E> Service<Request> for EndpointToTowerService<E>

--- a/poem/src/middleware/tracing_mw.rs
+++ b/poem/src/middleware/tracing_mw.rs
@@ -19,7 +19,7 @@ impl<E: Endpoint> Middleware<E> for Tracing {
     }
 }
 
-/// Endpoint for `Tracing` middleware.
+/// Endpoint for the `Tracing` middleware.
 pub struct TracingEndpoint<E> {
     inner: E,
 }


### PR DESCRIPTION
I have noticed some grammatical errors while reading through the documentation of this crate.
This PR is intended to fix the ones I noticed while not changing what they are supposed to convey.