### PR TITLE
Assign the description to the request object in OpenAPI

### DIFF
--- a/poem-openapi-derive/src/api.rs
+++ b/poem-openapi-derive/src/api.rs
@@ -396,9 +396,13 @@ fn generate_operation(
         });
 
         // request object meta
+        let param_desc = optional_literal(&param_description);
         request_meta.push(quote! {
             if <#arg_ty as #crate_name::ApiExtractor>::TYPES.contains(&#crate_name::ApiExtractorType::RequestObject) {
                 request = <#arg_ty as #crate_name::ApiExtractor>::request_meta();
+                if let Some(ref mut request) = request.as_mut() {
+                    request.description = #param_desc;
+                }
             }
         });
 


### PR DESCRIPTION
This fixes an issue where the doc comment description of an e.g. JSON parameter of a request would not show up in the generated API spec.

For example:
```rust
#[oai(path = "/users", method = "post", operation_id = "createUser")]
async fn create_user(
    &self,
    /// Parameters required to create a new user
    Json(params): Json<CreateUserParams>,
)
```
should translate to:
```yaml
  /users:
    post:
      requestBody:
        description: Parameters required to create a new user
        content:
          application/json; charset=utf-8:
            schema:
              $ref: '#/components/schemas/CreateUserParams'
        required: true
```
but without this change `description` is missing.