### PR TITLE
feat: implement conversion from libcookie to poem cookie

### DIFF
--- a/poem/src/web/cookie.rs
+++ b/poem/src/web/cookie.rs
@@ -328,6 +328,12 @@ impl<'a> FromRequest<'a> for Cookie {
     }
 }
 
+impl From<libcookie::Cookie<'static>> for Cookie {
+    fn from(value: libcookie::Cookie<'static>) -> Self {
+        Self(value)
+    }
+}
+
 /// A collection of cookies that tracks its modifications.
 ///
 /// # Example


### PR DESCRIPTION
My use-case is that I had a few utilities in my workspace that returns cookies (with `cookie-rs`), but I can't use them with `poem` because the cookie jar only accepts this library's cookie wrapper. Not sure if this is the best approach, though.