### PR TITLE
refactor: change type name delimiters from <> () [] to _

### DIFF
--- a/poem-openapi-derive/src/utils.rs
+++ b/poem-openapi-derive/src/utils.rs
@@ -191,13 +191,12 @@ pub(crate) fn create_object_name(
             use ::std::convert::From;
             let mut name = ::std::string::String::from(#name);
 
-            name.push('<');
+            name.push('_');
             name.push_str(&<#first as #crate_name::types::Type>::name());
             #(
-                name.push_str(", ");
+                name.push_str("_");
                 name.push_str(&<#tail as #crate_name::types::Type>::name());
             )*
-            name.push('>');
 
             name
         })

--- a/poem-openapi/src/types/base64_type.rs
+++ b/poem-openapi/src/types/base64_type.rs
@@ -38,7 +38,7 @@ impl<T: AsRef<[u8]> + Send + Sync> Type for Base64<T> {
     type RawElementValueType = Self;
 
     fn name() -> Cow<'static, str> {
-        "string(bytes)".into()
+        "string_bytes".into()
     }
 
     fn schema_ref() -> MetaSchemaRef {

--- a/poem-openapi/src/types/binary.rs
+++ b/poem-openapi/src/types/binary.rs
@@ -37,7 +37,7 @@ impl<T: AsRef<[u8]> + Send + Sync> Type for Binary<T> {
     type RawElementValueType = Self;
 
     fn name() -> Cow<'static, str> {
-        "string(binary)".into()
+        "string_binary".into()
     }
 
     fn schema_ref() -> MetaSchemaRef {

--- a/poem-openapi/src/types/external/array.rs
+++ b/poem-openapi/src/types/external/array.rs
@@ -15,7 +15,7 @@ impl<T: Type, const LEN: usize> Type for [T; LEN] {
     type RawElementValueType = T::RawValueType;
 
     fn name() -> Cow<'static, str> {
-        format!("[{}]", T::name()).into()
+        format!("array_{}", T::name()).into()
     }
 
     fn schema_ref() -> MetaSchemaRef {

--- a/poem-openapi/src/types/external/bson.rs
+++ b/poem-openapi/src/types/external/bson.rs
@@ -20,7 +20,7 @@ impl Type for ObjectId {
     type RawElementValueType = Self;
 
     fn name() -> Cow<'static, str> {
-        "string(oid)".into()
+        "string_oid".into()
     }
 
     fn schema_ref() -> MetaSchemaRef {

--- a/poem-openapi/src/types/external/btreemap.rs
+++ b/poem-openapi/src/types/external/btreemap.rs
@@ -19,7 +19,7 @@ where
     type RawElementValueType = V::RawValueType;
 
     fn name() -> Cow<'static, str> {
-        format!("map<string, {}>", V::name()).into()
+        format!("map_{}", V::name()).into()
     }
 
     fn schema_ref() -> MetaSchemaRef {

--- a/poem-openapi/src/types/external/btreeset.rs
+++ b/poem-openapi/src/types/external/btreeset.rs
@@ -19,7 +19,7 @@ impl<T: Type> Type for BTreeSet<T> {
     type RawElementValueType = T::RawValueType;
 
     fn name() -> Cow<'static, str> {
-        format!("[{}]", T::name()).into()
+        format!("set_{}", T::name()).into()
     }
 
     fn schema_ref() -> MetaSchemaRef {

--- a/poem-openapi/src/types/external/chrono.rs
+++ b/poem-openapi/src/types/external/chrono.rs
@@ -22,7 +22,7 @@ macro_rules! impl_datetime_types {
             type RawElementValueType = Self;
 
             fn name() -> Cow<'static, str> {
-                concat!($type_name, "(", $format, ")").into()
+                concat!($type_name, "_", $format).into()
             }
 
             fn schema_ref() -> MetaSchemaRef {
@@ -88,7 +88,7 @@ macro_rules! impl_naive_datetime_types {
             type RawElementValueType = Self;
 
             fn name() -> Cow<'static, str> {
-                concat!($type_name, "(", $format, ")").into()
+                concat!($type_name, "_", $format).into()
             }
 
             fn schema_ref() -> MetaSchemaRef {

--- a/poem-openapi/src/types/external/decimal.rs
+++ b/poem-openapi/src/types/external/decimal.rs
@@ -20,7 +20,7 @@ impl Type for Decimal {
     type RawElementValueType = Self;
 
     fn name() -> Cow<'static, str> {
-        "string(decimal)".into()
+        "string_decimal".into()
     }
 
     fn schema_ref() -> MetaSchemaRef {

--- a/poem-openapi/src/types/external/floats.rs
+++ b/poem-openapi/src/types/external/floats.rs
@@ -22,7 +22,7 @@ macro_rules! impl_type_for_floats {
             type RawElementValueType = Self;
 
             fn name() -> Cow<'static, str> {
-                format!("number({})", $format).into()
+                format!("number_{}", $format).into()
             }
 
             fn schema_ref() -> MetaSchemaRef {

--- a/poem-openapi/src/types/external/geo.rs
+++ b/poem-openapi/src/types/external/geo.rs
@@ -18,7 +18,7 @@ macro_rules! impl_geojson_types {
             type RawElementValueType = Self;
 
             fn name() -> ::std::borrow::Cow<'static, str> {
-                concat!("GeoJSON<", $name, ">").into()
+                concat!("GeoJSON_", $name).into()
             }
 
             fn schema_ref() -> crate::registry::MetaSchemaRef {

--- a/poem-openapi/src/types/external/hashmap.rs
+++ b/poem-openapi/src/types/external/hashmap.rs
@@ -26,7 +26,7 @@ where
     type RawElementValueType = V::RawValueType;
 
     fn name() -> Cow<'static, str> {
-        format!("map<string, {}>", V::name()).into()
+        format!("map_{}", V::name()).into()
     }
 
     fn schema_ref() -> MetaSchemaRef {

--- a/poem-openapi/src/types/external/hashset.rs
+++ b/poem-openapi/src/types/external/hashset.rs
@@ -23,7 +23,7 @@ impl<T: Type, R: Send + Sync> Type for HashSet<T, R> {
     type RawElementValueType = T::RawValueType;
 
     fn name() -> Cow<'static, str> {
-        format!("[{}]", T::name()).into()
+        format!("set_{}", T::name()).into()
     }
 
     fn schema_ref() -> MetaSchemaRef {

--- a/poem-openapi/src/types/external/humantime.rs
+++ b/poem-openapi/src/types/external/humantime.rs
@@ -19,7 +19,7 @@ impl Type for Duration {
     type RawElementValueType = Self;
 
     fn name() -> Cow<'static, str> {
-        "string(duration)".into()
+        "string_duration".into()
     }
 
     fn schema_ref() -> MetaSchemaRef {

--- a/poem-openapi/src/types/external/humantime_wrapper.rs
+++ b/poem-openapi/src/types/external/humantime_wrapper.rs
@@ -20,7 +20,7 @@ impl Type for Duration {
     type RawElementValueType = Self;
 
     fn name() -> Cow<'static, str> {
-        "string(duration)".into()
+        "string_duration".into()
     }
 
     fn schema_ref() -> MetaSchemaRef {

--- a/poem-openapi/src/types/external/integers.rs
+++ b/poem-openapi/src/types/external/integers.rs
@@ -22,7 +22,7 @@ macro_rules! impl_type_for_integers {
             type RawElementValueType = Self;
 
             fn name() -> Cow<'static, str> {
-                format!("integer({})", $format).into()
+                format!("integer_{}", $format).into()
             }
 
             fn schema_ref() -> MetaSchemaRef {

--- a/poem-openapi/src/types/external/ip.rs
+++ b/poem-openapi/src/types/external/ip.rs
@@ -37,7 +37,7 @@ macro_rules! impl_type_for_ip {
             type RawElementValueType = Self;
 
             fn name() -> Cow<'static, str> {
-                format!("string({})", $format).into()
+                format!("string_{}", $format).into()
             }
 
             fn schema_ref() -> MetaSchemaRef {

--- a/poem-openapi/src/types/external/optional.rs
+++ b/poem-openapi/src/types/external/optional.rs
@@ -19,7 +19,7 @@ impl<T: Type> Type for Option<T> {
     type RawElementValueType = T::RawElementValueType;
 
     fn name() -> Cow<'static, str> {
-        format!("optional<{}>", T::name()).into()
+        format!("optional_{}", T::name()).into()
     }
 
     fn schema_ref() -> MetaSchemaRef {

--- a/poem-openapi/src/types/external/prost_wkt_types/struct.rs
+++ b/poem-openapi/src/types/external/prost_wkt_types/struct.rs
@@ -15,7 +15,7 @@ impl Type for prost_wkt_types::Struct {
     type RawElementValueType = <Value as Type>::RawValueType;
 
     fn name() -> Cow<'static, str> {
-        "Protobuf Struct".into()
+        "Protobuf_Struct".into()
     }
 
     fn schema_ref() -> MetaSchemaRef {

--- a/poem-openapi/src/types/external/prost_wkt_types/value.rs
+++ b/poem-openapi/src/types/external/prost_wkt_types/value.rs
@@ -15,7 +15,7 @@ impl Type for prost_wkt_types::Value {
     type RawElementValueType = prost_wkt_types::Value;
 
     fn name() -> Cow<'static, str> {
-        "Protobuf Value".into()
+        "Protobuf_Value".into()
     }
 
     fn schema_ref() -> MetaSchemaRef {

--- a/poem-openapi/src/types/external/regex.rs
+++ b/poem-openapi/src/types/external/regex.rs
@@ -20,7 +20,7 @@ impl Type for Regex {
     type RawElementValueType = Self;
 
     fn name() -> Cow<'static, str> {
-        "string(regex)".into()
+        "string_regex".into()
     }
 
     fn schema_ref() -> MetaSchemaRef {

--- a/poem-openapi/src/types/external/slice.rs
+++ b/poem-openapi/src/types/external/slice.rs
@@ -15,7 +15,7 @@ impl<T: Type> Type for &[T] {
     type RawElementValueType = T::RawValueType;
 
     fn name() -> Cow<'static, str> {
-        format!("[{}]", T::name()).into()
+        format!("slice_{}", T::name()).into()
     }
 
     fn schema_ref() -> MetaSchemaRef {

--- a/poem-openapi/src/types/external/time.rs
+++ b/poem-openapi/src/types/external/time.rs
@@ -23,7 +23,7 @@ impl Type for OffsetDateTime {
     type RawElementValueType = Self;
 
     fn name() -> Cow<'static, str> {
-        "string(date-time)".into()
+        "string_date-time".into()
     }
 
     fn schema_ref() -> MetaSchemaRef {
@@ -83,7 +83,7 @@ macro_rules! impl_naive_datetime_types {
             type RawElementValueType = Self;
 
             fn name() -> Cow<'static, str> {
-                concat!($type_name, "(", $format, ")").into()
+                concat!($type_name, "_", $format).into()
             }
 
             fn schema_ref() -> MetaSchemaRef {

--- a/poem-openapi/src/types/external/uri.rs
+++ b/poem-openapi/src/types/external/uri.rs
@@ -22,7 +22,7 @@ impl Type for Uri {
     type RawElementValueType = Self;
 
     fn name() -> Cow<'static, str> {
-        "string(uri)".into()
+        "string_uri".into()
     }
 
     fn schema_ref() -> MetaSchemaRef {

--- a/poem-openapi/src/types/external/url.rs
+++ b/poem-openapi/src/types/external/url.rs
@@ -20,7 +20,7 @@ impl Type for Url {
     type RawElementValueType = Self;
 
     fn name() -> Cow<'static, str> {
-        "string(url)".into()
+        "string_url".into()
     }
 
     fn schema_ref() -> MetaSchemaRef {

--- a/poem-openapi/src/types/external/uuid.rs
+++ b/poem-openapi/src/types/external/uuid.rs
@@ -20,7 +20,7 @@ impl Type for Uuid {
     type RawElementValueType = Self;
 
     fn name() -> Cow<'static, str> {
-        "string(uuid)".into()
+        "string_uuid".into()
     }
 
     fn schema_ref() -> MetaSchemaRef {

--- a/poem-openapi/src/types/external/vec.rs
+++ b/poem-openapi/src/types/external/vec.rs
@@ -19,7 +19,7 @@ impl<T: Type> Type for Vec<T> {
     type RawElementValueType = T::RawValueType;
 
     fn name() -> Cow<'static, str> {
-        format!("[{}]", T::name()).into()
+        format!("list_{}", T::name()).into()
     }
 
     fn schema_ref() -> MetaSchemaRef {

--- a/poem-openapi/src/types/maybe_undefined.rs
+++ b/poem-openapi/src/types/maybe_undefined.rs
@@ -316,7 +316,7 @@ impl<T: Type> Type for MaybeUndefined<T> {
     type RawElementValueType = T::RawElementValueType;
 
     fn name() -> Cow<'static, str> {
-        format!("optional<{}>", T::name()).into()
+        format!("optional_{}", T::name()).into()
     }
 
     fn schema_ref() -> MetaSchemaRef {

--- a/poem-openapi/src/types/mod.rs
+++ b/poem-openapi/src/types/mod.rs
@@ -441,7 +441,7 @@ mod tests {
     #[allow(clippy::assertions_on_constants)]
     fn arc_type() {
         assert!(Arc::<i32>::IS_REQUIRED);
-        assert_eq!(Arc::<i32>::name(), "integer(int32)");
+        assert_eq!(Arc::<i32>::name(), "integer_int32");
         assert_eq!(Arc::new(100).as_raw_value(), Some(&100));
 
         let value: Arc<i32> =
@@ -472,7 +472,7 @@ mod tests {
     #[allow(unused_allocation)]
     fn box_type() {
         assert!(Box::<i32>::IS_REQUIRED);
-        assert_eq!(Box::<i32>::name(), "integer(int32)");
+        assert_eq!(Box::<i32>::name(), "integer_int32");
         assert_eq!(Box::new(100).as_raw_value(), Some(&100));
 
         let value: Box<i32> =

--- a/poem-openapi/src/types/multipart/upload.rs
+++ b/poem-openapi/src/types/multipart/upload.rs
@@ -92,7 +92,7 @@ impl Type for Upload {
     type RawElementValueType = Self;
 
     fn name() -> Cow<'static, str> {
-        "string(binary)".into()
+        "string_binary".into()
     }
 
     fn schema_ref() -> MetaSchemaRef {

--- a/poem-openapi/src/types/string_types.rs
+++ b/poem-openapi/src/types/string_types.rs
@@ -48,7 +48,7 @@ macro_rules! impl_string_types {
             type RawElementValueType = Self;
 
             fn name() -> Cow<'static, str> {
-                concat!($type_name, "(", $format, ")").into()
+                concat!($type_name, "_", $format).into()
             }
 
             fn schema_ref() -> MetaSchemaRef {

--- a/poem-openapi/tests/object.rs
+++ b/poem-openapi/tests/object.rs
@@ -45,7 +45,7 @@ fn generics() {
 
     assert_eq!(
         <Obj<i32, i64>>::name(),
-        "Obj<integer(int32), integer(int64)>"
+        "Obj_integer_int32_integer_int64"
     );
     let meta = get_meta::<Obj<i32, i64>>();
     assert_eq!(meta.properties[0].1.unwrap_inline().ty, "integer");
@@ -56,7 +56,7 @@ fn generics() {
 
     assert_eq!(
         <Obj<f32, f64>>::name(),
-        "Obj<number(float), number(double)>"
+        "Obj_number_float_number_double"
     );
     let meta = get_meta::<Obj<f32, f64>>();
     assert_eq!(meta.properties[0].1.unwrap_inline().ty, "number");

--- a/poem-openapi/tests/query.rs
+++ b/poem-openapi/tests/query.rs
@@ -1,0 +1,68 @@
+use poem::{
+    http::{Method, StatusCode},
+    test::TestClient,
+    Error,
+};
+use poem_openapi::{
+    param::Query,
+    payload::{Json, PlainText},
+    registry::MetaApi,
+    types::{MaybeUndefined, ToJSON},
+    ApiResponse, OpenApi, OpenApiService,
+};
+use serde_json::Value;
+
+#[tokio::test]
+async fn query_explode_false() {
+    #[derive(ApiResponse)]
+    #[oai(bad_request_handler = "bad_request_handler")]
+    enum MyResponse {
+        /// Ok
+        #[oai(status = 200)]
+        Ok(Json<Option<Value>>),
+        /// Bad Request
+        #[oai(status = 400)]
+        BadRequest(PlainText<String>),
+    }
+
+    fn bad_request_handler(err: Error) -> MyResponse {
+        MyResponse::BadRequest(PlainText(format!("!!! {err}")))
+    }
+
+    const fn none<T>() -> MaybeUndefined<T> {
+        MaybeUndefined::Undefined
+    }
+
+    struct Api;
+
+    #[OpenApi]
+    impl Api {
+        #[oai(path = "/abc", method = "post")]
+        async fn test(
+            &self,
+            #[oai(explode = false, default = "none::<Vec<u32>>")] fields: Query<
+                MaybeUndefined<Vec<u32>>,
+            >,
+        ) -> MyResponse {
+            MyResponse::Ok(Json(fields.0.to_json()))
+        }
+    }
+
+    let meta: MetaApi = Api::meta().remove(0);
+    assert_eq!(meta.paths[0].path, "/abc");
+    assert_eq!(meta.paths[0].operations[0].method, Method::POST);
+
+    let ep = OpenApiService::new(Api, "test", "1.0");
+    let cli = TestClient::new(ep);
+
+    let resp = cli.post("/abc").query("fields", &"1,2,3").send().await;
+    resp.assert_status_is_ok();
+    resp.assert_json(&[1, 2, 3]).await;
+
+    let resp = cli.post("/abc").query("fields", &"").send().await;
+    resp.assert_status(StatusCode::BAD_REQUEST);
+
+    let resp = cli.post("/abc").send().await;
+    resp.assert_status_is_ok();
+    resp.assert_json(Value::Null).await;
+}

--- a/poem-openapi/tests/union.rs
+++ b/poem-openapi/tests/union.rs
@@ -514,11 +514,11 @@ async fn generics() {
 
     assert_eq!(
         <MyObj<i32, i64>>::schema_ref(),
-        MetaSchemaRef::Reference("MyObj<integer(int32), integer(int64)>".to_string())
+        MetaSchemaRef::Reference("MyObj_integer_int32_integer_int64".to_string())
     );
     assert_eq!(
         <MyObj<f32, f64>>::schema_ref(),
-        MetaSchemaRef::Reference("MyObj<number(float), number(double)>".to_string())
+        MetaSchemaRef::Reference("MyObj_number_float_number_double".to_string())
     );
 
     assert_eq!(schema_i32_i64.any_of[0], i32::schema_ref());


### PR DESCRIPTION
This change aligns with OpenAPI object naming conventions, where special characters like <, (), and [] can cause issues in schema generation and parsing. Replacing them with underscores (_) ensures compatibility with OpenAPI specifications, improving both readability and tool support.

This update maintains functionality while adhering to standard naming rules for better interoperability.

https://github.com/poem-web/poem/pull/671
https://github.com/poem-web/poem/issues/670
https://github.com/poem-web/poem/issues/774