### PR TITLE
Fix grammar in "a OpenAPI"

### DIFF
--- a/poem-openapi/CHANGELOG.md
+++ b/poem-openapi/CHANGELOG.md
@@ -538,7 +538,7 @@ enum UploadImageRequest {
 
 # [1.0.35] 2021-12-05
 
-- If a OpenAPI name conflict is detected when creating schema, it will cause panic.
+- If an OpenAPI name conflict is detected when creating schema, it will cause panic.
 
 # [1.0.33] 2021-11-30
 

--- a/poem-openapi/src/base.rs
+++ b/poem-openapi/src/base.rs
@@ -88,7 +88,7 @@ impl<T> Default for ExtractParamOptions<T> {
     }
 }
 
-/// Represents a OpenAPI extractor.
+/// Represents an OpenAPI extractor.
 ///
 /// # Provided Implementations
 ///
@@ -221,7 +221,7 @@ impl<'a, T: FromRequest<'a>> ApiExtractor<'a> for T {
     }
 }
 
-/// Represents a OpenAPI response content object.
+/// Represents an OpenAPI response content object.
 pub trait ResponseContent {
     /// Returns the media types in this content.
     fn media_types() -> Vec<MetaMediaType>;
@@ -244,7 +244,7 @@ impl<T: Payload> ResponseContent for T {
     }
 }
 
-/// Represents a OpenAPI responses object.
+/// Represents an OpenAPI responses object.
 ///
 /// # Provided Implementations
 ///
@@ -366,7 +366,7 @@ where
     fn register(_registry: &mut Registry) {}
 }
 
-/// Represents a OpenAPI tags.
+/// Represents an OpenAPI tags.
 pub trait Tags {
     /// Register this tag type to registry.
     fn register(&self, registry: &mut Registry);
@@ -395,7 +395,7 @@ impl Display for OperationId {
     }
 }
 
-/// Represents a OpenAPI object.
+/// Represents an OpenAPI object.
 pub trait OpenApi: Sized {
     /// Gets metadata of this API object.
     fn meta() -> Vec<MetaApi>;

--- a/poem-openapi/src/docs/enum.md
+++ b/poem-openapi/src/docs/enum.md
@@ -1,4 +1,4 @@
-Define a OpenAPI enum
+Define an OpenAPI enum
 
 # Macro parameters
 

--- a/poem-openapi/src/docs/multipart.md
+++ b/poem-openapi/src/docs/multipart.md
@@ -1,4 +1,4 @@
-Define a OpenAPI payload.
+Define an OpenAPI payload.
 
 # Macro parameters
 

--- a/poem-openapi/src/docs/object.md
+++ b/poem-openapi/src/docs/object.md
@@ -1,4 +1,4 @@
-Define a OpenAPI object
+Define an OpenAPI object
 
 # Macro parameters
 

--- a/poem-openapi/src/docs/openapi.md
+++ b/poem-openapi/src/docs/openapi.md
@@ -1,4 +1,4 @@
-Define a OpenAPI.
+Define an OpenAPI.
 
 # Macro parameters
 

--- a/poem-openapi/src/docs/request.md
+++ b/poem-openapi/src/docs/request.md
@@ -1,4 +1,4 @@
-Define a OpenAPI request.
+Define an OpenAPI request.
 
 # Item parameters
 

--- a/poem-openapi/src/docs/response.md
+++ b/poem-openapi/src/docs/response.md
@@ -1,4 +1,4 @@
-Define a OpenAPI response.
+Define an OpenAPI response.
 
 # Macro parameters
 

--- a/poem-openapi/src/docs/response_content.md
+++ b/poem-openapi/src/docs/response_content.md
@@ -1,4 +1,4 @@
-Define a OpenAPI response content.
+Define an OpenAPI response content.
 
 # Item parameters
 

--- a/poem-openapi/src/docs/security_scheme.md
+++ b/poem-openapi/src/docs/security_scheme.md
@@ -1,4 +1,4 @@
-Define a OpenAPI Security Scheme.
+Define an OpenAPI Security Scheme.
 
 # Macro parameters
 

--- a/poem-openapi/src/docs/tags.md
+++ b/poem-openapi/src/docs/tags.md
@@ -1,4 +1,4 @@
-Define a OpenAPI Tags.
+Define an OpenAPI Tags.
 
 # Macro parameters
 

--- a/poem-openapi/src/docs/union.md
+++ b/poem-openapi/src/docs/union.md
@@ -1,4 +1,4 @@
-Define a OpenAPI discriminator object.
+Define an OpenAPI discriminator object.
 
 # Macro parameters
 

--- a/poem-openapi/src/docs/webhook.md
+++ b/poem-openapi/src/docs/webhook.md
@@ -1,4 +1,4 @@
-Define a OpenApi webhooks.
+Define an OpenAPI webhooks.
 
 # Macro parameters
 

--- a/poem-openapi/src/types/mod.rs
+++ b/poem-openapi/src/types/mod.rs
@@ -27,7 +27,7 @@ pub use string_types::Password;
 
 use crate::registry::{MetaSchemaRef, Registry};
 
-/// Represents a OpenAPI type.
+/// Represents an OpenAPI type.
 pub trait Type: Send + Sync {
     /// If it is `true`, it means that this type is required.
     const IS_REQUIRED: bool;


### PR DESCRIPTION
Simple find+replace from
`a OpenAPI`
to
`an OpenAPI`

Also caught a place where the original capitalisation was `OpenApi`