### PR TITLE
Add description to Union descriminator object schema

### DIFF
--- a/poem-openapi-derive/src/union.rs
+++ b/poem-openapi-derive/src/union.rs
@@ -151,6 +151,7 @@ pub(crate) fn generate(args: DeriveInput) -> GeneratorResult<TokenStream> {
                         }
 
                         let schema = #crate_name::registry::MetaSchema {
+                            description: #description,
                             all_of: ::std::vec![
                                 #crate_name::registry::MetaSchemaRef::Inline(::std::boxed::Box::new(#crate_name::registry::MetaSchema {
                                     required: #required,


### PR DESCRIPTION
The intermediate "descriptor" object generated by the Union derive macro currenlty lacks description.
If you lint your OpenAPI spec, this will be flagged by the missing description rule. This change takes care of that.