### PR TITLE
Pass `ParsePayload<T>::IS_REQUIRED` to `T` instead of defaulting to `…true`

### DIFF
--- a/poem-openapi/src/payload/json.rs
+++ b/poem-openapi/src/payload/json.rs
@@ -51,7 +51,7 @@ impl<T: Type> Payload for Json<T> {
 }
 
 impl<T: ParseFromJSON> ParsePayload for Json<T> {
-    const IS_REQUIRED: bool = true;
+    const IS_REQUIRED: bool = T::IS_REQUIRED;
 
     async fn from_request(request: &Request, body: &mut RequestBody) -> Result<Self> {
         let data = Vec::<u8>::from_request(request, body).await?;


### PR DESCRIPTION
Currently, it's impossible to request or respond with an optional Json body. 
Example:
``` rust
 #[oai(path = "/opa", method = "get")]
    pub async fn get(&self, Json(test): Json<Option<Klaboom>>) -> Json<String> {
        Json("Hello, world!".to_string())
    }
```
expands to openapi:
``` json
"/opa": {
      "get": {
        "requestBody": {
          "content": {
            "application/json; charset=utf-8": {
              "schema": {
                "$ref": "#/components/schemas/Klaboom"
              }
            }
          },
          "required": true
        },
 ...
}
```

This PR passes the `IS_REQUIRED` field to the child `T`, which solves this.
