### PR TITLE
allow path in status for ApiResponse

### DIFF
--- a/poem-openapi-derive/src/common_args.rs
+++ b/poem-openapi-derive/src/common_args.rs
@@ -224,7 +224,7 @@ pub(crate) struct ExtraHeader {
 
 pub(crate) enum LitOrPath<T> {
     Lit(T),
-    Path(syn::Ident),
+    Path(syn::Path),
 }
 
 impl<T> darling::FromMeta for LitOrPath<T>
@@ -234,61 +234,61 @@ where
     fn from_nested_meta(item: &darling::ast::NestedMeta) -> darling::Result<Self> {
         T::from_nested_meta(item)
             .map(Self::Lit)
-            .or_else(|_| syn::Ident::from_nested_meta(item).map(Self::Path))
+            .or_else(|_| syn::Path::from_nested_meta(item).map(Self::Path))
     }
 
     fn from_meta(item: &syn::Meta) -> darling::Result<Self> {
         T::from_meta(item)
             .map(Self::Lit)
-            .or_else(|_| syn::Ident::from_meta(item).map(Self::Path))
+            .or_else(|_| syn::Path::from_meta(item).map(Self::Path))
     }
 
     fn from_none() -> Option<Self> {
         T::from_none()
             .map(Self::Lit)
-            .or_else(|| syn::Ident::from_none().map(Self::Path))
+            .or_else(|| syn::Path::from_none().map(Self::Path))
     }
 
     fn from_word() -> darling::Result<Self> {
         T::from_word()
             .map(Self::Lit)
-            .or_else(|_| syn::Ident::from_word().map(Self::Path))
+            .or_else(|_| syn::Path::from_word().map(Self::Path))
     }
 
     fn from_list(items: &[darling::ast::NestedMeta]) -> darling::Result<Self> {
         T::from_list(items)
             .map(Self::Lit)
-            .or_else(|_| syn::Ident::from_list(items).map(Self::Path))
+            .or_else(|_| syn::Path::from_list(items).map(Self::Path))
     }
 
     fn from_value(value: &Lit) -> darling::Result<Self> {
         T::from_value(value)
             .map(Self::Lit)
-            .or_else(|_| syn::Ident::from_value(value).map(Self::Path))
+            .or_else(|_| syn::Path::from_value(value).map(Self::Path))
     }
 
     fn from_expr(expr: &syn::Expr) -> darling::Result<Self> {
         T::from_expr(expr)
             .map(Self::Lit)
-            .or_else(|_| syn::Ident::from_expr(expr).map(Self::Path))
+            .or_else(|_| syn::Path::from_expr(expr).map(Self::Path))
     }
 
     fn from_char(value: char) -> darling::Result<Self> {
         T::from_char(value)
             .map(Self::Lit)
-            .or_else(|_| syn::Ident::from_char(value).map(Self::Path))
+            .or_else(|_| syn::Path::from_char(value).map(Self::Path))
     }
 
     fn from_string(value: &str) -> darling::Result<Self> {
         T::from_string(value)
             .map(Self::Lit)
-            .or_else(|_| syn::Ident::from_string(value).map(Self::Path))
+            .or_else(|_| syn::Path::from_string(value).map(Self::Path))
     }
 
     fn from_bool(value: bool) -> darling::Result<Self> {
         T::from_bool(value)
             .map(Self::Lit)
-            .or_else(|_| syn::Ident::from_bool(value).map(Self::Path))
+            .or_else(|_| syn::Path::from_bool(value).map(Self::Path))
     }
 }
 

--- a/poem-openapi-derive/src/common_args.rs
+++ b/poem-openapi-derive/src/common_args.rs
@@ -222,6 +222,76 @@ pub(crate) struct ExtraHeader {
     pub(crate) deprecated: bool,
 }
 
+pub(crate) enum LitOrPath<T> {
+    Lit(T),
+    Path(syn::Ident),
+}
+
+impl<T> darling::FromMeta for LitOrPath<T>
+where
+    T: darling::FromMeta,
+{
+    fn from_nested_meta(item: &darling::ast::NestedMeta) -> darling::Result<Self> {
+        T::from_nested_meta(item)
+            .map(Self::Lit)
+            .or_else(|_| syn::Ident::from_nested_meta(item).map(Self::Path))
+    }
+
+    fn from_meta(item: &syn::Meta) -> darling::Result<Self> {
+        T::from_meta(item)
+            .map(Self::Lit)
+            .or_else(|_| syn::Ident::from_meta(item).map(Self::Path))
+    }
+
+    fn from_none() -> Option<Self> {
+        T::from_none()
+            .map(Self::Lit)
+            .or_else(|| syn::Ident::from_none().map(Self::Path))
+    }
+
+    fn from_word() -> darling::Result<Self> {
+        T::from_word()
+            .map(Self::Lit)
+            .or_else(|_| syn::Ident::from_word().map(Self::Path))
+    }
+
+    fn from_list(items: &[darling::ast::NestedMeta]) -> darling::Result<Self> {
+        T::from_list(items)
+            .map(Self::Lit)
+            .or_else(|_| syn::Ident::from_list(items).map(Self::Path))
+    }
+
+    fn from_value(value: &Lit) -> darling::Result<Self> {
+        T::from_value(value)
+            .map(Self::Lit)
+            .or_else(|_| syn::Ident::from_value(value).map(Self::Path))
+    }
+
+    fn from_expr(expr: &syn::Expr) -> darling::Result<Self> {
+        T::from_expr(expr)
+            .map(Self::Lit)
+            .or_else(|_| syn::Ident::from_expr(expr).map(Self::Path))
+    }
+
+    fn from_char(value: char) -> darling::Result<Self> {
+        T::from_char(value)
+            .map(Self::Lit)
+            .or_else(|_| syn::Ident::from_char(value).map(Self::Path))
+    }
+
+    fn from_string(value: &str) -> darling::Result<Self> {
+        T::from_string(value)
+            .map(Self::Lit)
+            .or_else(|_| syn::Ident::from_string(value).map(Self::Path))
+    }
+
+    fn from_bool(value: bool) -> darling::Result<Self> {
+        T::from_bool(value)
+            .map(Self::Lit)
+            .or_else(|_| syn::Ident::from_bool(value).map(Self::Path))
+    }
+}
+
 #[derive(FromMeta)]
 pub(crate) struct CodeSample {
     pub(crate) lang: String,

--- a/poem-openapi/tests/api.rs
+++ b/poem-openapi/tests/api.rs
@@ -353,13 +353,15 @@ async fn payload_request() {
 
 #[tokio::test]
 async fn response() {
+    const ALREADY_EXISTS_CODE: u16 = 409;
+
     #[derive(ApiResponse)]
     enum MyResponse {
         /// Ok
         #[oai(status = 200)]
         Ok,
         /// Already exists
-        #[oai(status = 409)]
+        #[oai(status = ALREADY_EXISTS_CODE)]
         AlreadyExists(Json<u16>),
         /// Default
         Default(StatusCode, PlainText<String>),


### PR DESCRIPTION
This mr adds ability to use constant as status code in `ApiResponse` macro. I found it to be extremely convenient in my codebase. It should be easy to use the same approach in other places where literal is expected.

```rust
const OK_STATUS: u16 = 200;

#[derive(ApiResponse)]
enum MyResponse {
    #[oai(status = OK_STATUS)]
    Ok,
}
```