### PR TITLE
make Json from poem-openapi derive Default because Json from poem does

### DIFF
--- a/poem-openapi/src/payload/json.rs
+++ b/poem-openapi/src/payload/json.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 
 /// A JSON payload.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Default)]
 pub struct Json<T>(pub T);
 
 impl<T> Deref for Json<T> {


### PR DESCRIPTION
`Json` from `poem/src/web/json.rs` derives `Default` but `Json` from `poem-openapi/src/payload/json.rs` does not.
This mr makes them both derive `Default`