### PR TITLE
fix(poem-openapi-derive): Allow different path param names on same route

### DIFF
--- a/poem-openapi-derive/src/api.rs
+++ b/poem-openapi-derive/src/api.rs
@@ -241,6 +241,8 @@ fn generate_operation(
     let mut params_meta = Vec::new();
     let mut security = Vec::new();
 
+    let mut path_param_count = 0;
+
     for i in 1..item_method.sig.inputs.len() {
         let arg = &mut item_method.sig.inputs[i];
         let (arg_ident, mut arg_ty, operation_param, param_description) = match arg {
@@ -272,6 +274,12 @@ fn generate_operation(
                 return Err(Error::new_spanned(item_method, "Invalid method definition.").into());
             }
         };
+        let is_path = match &*arg_ty {
+            syn::Type::Path(syn::TypePath { qself: _, path }) => {
+                path.segments.iter().any(|v| v.ident.to_string() == "Path")
+            }
+            _ => false,
+        };
 
         RemoveLifetime.visit_type_mut(&mut arg_ty);
 
@@ -280,6 +288,13 @@ fn generate_operation(
             .name
             .clone()
             .unwrap_or_else(|| arg_ident.unraw().to_string());
+        let extract_param_name = is_path
+            .then(|| {
+                let n = format!("param{path_param_count}");
+                path_param_count += 1;
+                n
+            })
+            .unwrap_or_else(|| param_name.clone());
         use_args.push(pname.clone());
 
         if !hidden {
@@ -349,7 +364,7 @@ fn generate_operation(
 
         parse_args.push(quote! {
             let mut param_opts = #crate_name::ExtractParamOptions {
-                name: #param_name,
+                name: #extract_param_name,
                 default_value: #default_value,
                 example_value: #example_value,
                 explode: #explode,

--- a/poem-openapi-derive/src/utils.rs
+++ b/poem-openapi-derive/src/utils.rs
@@ -117,6 +117,7 @@ pub(crate) fn convert_oai_path(path: &SpannedValue<String>) -> Result<(String, S
     let mut oai_path = String::new();
     let mut new_path = String::new();
     let mut vars = HashSet::new();
+    let mut param_count = 0;
 
     for s in path.split('/') {
         if s.is_empty() {
@@ -129,7 +130,8 @@ pub(crate) fn convert_oai_path(path: &SpannedValue<String>) -> Result<(String, S
             oai_path.push('}');
 
             new_path.push_str("/:");
-            new_path.push_str(var);
+            new_path.push_str(&format!("param{param_count}"));
+            param_count += 1;
 
             if !vars.insert(var) {
                 return Err(Error::new(


### PR DESCRIPTION
This commits add automatic renaming of path parameters in route table and param extraction.
When having two same routes with different method and different param names, it resulted in one of them returning 405 instead of firing the handler.

This fix is somewhat janky, because it checks if the extracted param type is `Path` and then it renames is to `param{i}`. There could be more edge cases down the line, but for now it passess all the tests.

Fixes: https://github.com/poem-web/poem/issues/948
Related: https://github.com/poem-web/poem/issues/429