### PR TITLE
Correct server object reference URL anchor

### DIFF
--- a/poem-openapi/src/openapi.rs
+++ b/poem-openapi/src/openapi.rs
@@ -291,7 +291,7 @@ impl<T, W> OpenApiService<T, W> {
 
     /// Appends a server to the API container.
     ///
-    /// Reference: <https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#serverObject>
+    /// Reference: <https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#server-object>
     #[must_use]
     pub fn server(mut self, server: impl Into<ServerObject>) -> Self {
         let server = server.into();


### PR DESCRIPTION
This PR fixes the anchor in the reference URL for the OpenAPI server object documentation. The original link pointed to `#serverObject`, but the correct anchor in the OpenAPI Specification uses hyphen-case (`#server-object`).