### PR TITLE
feat(openapi): reflect fallback security scheme in spec

### DIFF
--- a/poem-openapi-derive/src/api.rs
+++ b/poem-openapi-derive/src/api.rs
@@ -411,6 +411,9 @@ fn generate_operation(
                         (security_name, ::std::vec![#(#crate_name::OAuthScopes::name(&#scopes)),*])
                     ]));
                 }
+                if <#arg_ty as #crate_name::ApiExtractor>::has_security_fallback() {
+                    security.push(::std::collections::HashMap::<&'static str, ::std::vec::Vec<&'static str>>::new());
+                }
             }
         });
     }

--- a/poem-openapi-derive/src/security_scheme.rs
+++ b/poem-openapi-derive/src/security_scheme.rs
@@ -496,6 +496,7 @@ pub(crate) fn generate(args: DeriveInput) -> GeneratorResult<TokenStream> {
             let mut registers = Vec::new();
             let mut security_schemes = Vec::new();
             let mut from_requests = Vec::new();
+            let mut has_fallback = false;
 
             if items.is_empty() {
                 return Err(Error::new_spanned(ident, "At least one member is required.").into());
@@ -503,6 +504,7 @@ pub(crate) fn generate(args: DeriveInput) -> GeneratorResult<TokenStream> {
 
             for item in items {
                 if item.fallback {
+                    has_fallback = true;
                     continue;
                 }
 
@@ -558,6 +560,10 @@ pub(crate) fn generate(args: DeriveInput) -> GeneratorResult<TokenStream> {
                         let mut security_schemes = ::std::vec![];
                         #(#security_schemes)*
                         security_schemes
+                    }
+
+                    fn has_security_fallback() -> bool {
+                        #has_fallback
                     }
 
                     async fn from_request(

--- a/poem-openapi/src/base.rs
+++ b/poem-openapi/src/base.rs
@@ -176,6 +176,11 @@ pub trait ApiExtractor<'a>: Sized {
         vec![]
     }
 
+    /// Returns `true` if the extractor is a security scheme with a fallback.
+    fn has_security_fallback() -> bool {
+        false
+    }
+
     /// Returns the location of the parameter if this extractor is parameter.
     fn param_in() -> Option<MetaParamIn> {
         None


### PR DESCRIPTION
This makes it so that security schemes with a fallback:

```rust
#[derive(SecurityScheme)]
enum MySecurityScheme {
    MySecuritySchemeBasic(MySecuritySchemeBasic),
    #[oai(fallback)]
    NoAuth,
}
```

Will be reflected in the OpenAPI schema:

```jsonc
"security": [
  {
    "MySecuritySchemeBasic": []
  },
  {} // <-- the fallback scheme
]
```

This is the correct way to define optional security schemes, according to the [official specification](https://github.com/OAI/OpenAPI-Specification/blob/d237e681c2bce77413f0dfc4278e168d6ed0edb0/versions/3.0.3.md#optional-oauth2-security) as of version `3.0.3`.

Closes https://github.com/poem-web/poem/issues/959