### PR TITLE
fix(poem-openapi): handle additional_properties correctly in flatten

### DIFF
--- a/poem-openapi/tests/object.rs
+++ b/poem-openapi/tests/object.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use poem_openapi::{
     registry::{MetaExternalDocument, MetaSchema, MetaSchemaRef, Registry},
     types::{Example, ParseFromJSON, ToJSON, Type},
@@ -651,6 +653,47 @@ fn flatten_field() {
     assert_eq!(
         Obj::parse_from_json(Some(json!({"a": 100, "b": 200, "c":
 300})))
+        .unwrap(),
+        obj
+    );
+}
+
+#[test]
+fn flatten_hash_map() {
+    #[derive(Object, Debug, Eq, PartialEq)]
+    struct Obj1 {
+        a: i32,
+        b: i32,
+    }
+
+    #[derive(Object, Debug, Eq, PartialEq)]
+    struct Obj {
+        c: i32,
+        #[oai(flatten)]
+        map: HashMap<String, Obj1>,
+    }
+
+    let meta = get_meta::<Obj>();
+    assert_eq!(meta.required, vec!["c"]);
+    assert_eq!(meta.properties[0].0, "c");
+    assert_eq!(
+        meta.additional_properties,
+        Some(Box::new(MetaSchemaRef::Reference("Obj1".to_owned())))
+    );
+
+    let mut map = HashMap::new();
+    map.insert("k1".to_owned(), Obj1 { a: 100, b: 200 });
+    map.insert("k2".to_owned(), Obj1 { a: 300, b: 400 });
+    let obj = Obj { map, c: 300 };
+
+    assert_eq!(
+        obj.to_json(),
+        Some(json!({"k1": { "a": 100, "b": 200 }, "k2": { "a": 300, "b": 400 }, "c": 300}))
+    );
+    assert_eq!(
+        Obj::parse_from_json(Some(
+            json!({"k1": { "a": 100, "b": 200 }, "k2": { "a": 300, "b": 400 }, "c": 300})
+        ))
         .unwrap(),
         obj
     );


### PR DESCRIPTION
Fixes the generated documentation for a type like
```rust
#[derive(Object)]
struct SomeObject {
    fixed: u32,

    #[oai(flatten)]
    items: HashMap<String, u64>
}
```

Currently, such a type shows no documentation for `items`, because `HashMap<String, ...>` only contains `additionalProperties` in the schema. This PR adds tracking of `additionalProperties` in addition to `properties` and `required` when using `flatten`.

In principle we can only support one flattened type with `additionalProperties`, but it wasn't clear to me how to enforce this, so instead this PR just keeps track of the `additionalProperties` of the LAST `flatten`-ed field.