### PR TITLE
feat(openapi): add support for server variables

### DIFF
--- a/poem-openapi/src/registry/mod.rs
+++ b/poem-openapi/src/registry/mod.rs
@@ -542,6 +542,20 @@ pub struct MetaServer {
     pub url: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub variables: BTreeMap<String, MetaServerVariable>,
+}
+
+#[derive(Debug, Eq, PartialEq, Serialize, Clone)]
+pub struct MetaServerVariable {
+    pub default: String,
+
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub description: String,
+
+    #[serde(rename = "enum", skip_serializing_if = "Vec::is_empty")]
+    pub enum_values: Vec<String>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize)]


### PR DESCRIPTION
Add support for server variables like:
```rust
    .server(
                ServerObject::new("https://{environment}.example.com/{organization}/{tenant}/api/v1")
                .enum_variable(
                    "environment",
                    "The environment to call (e.g. alpha).",
                    "alpha",
                    vec!["alpha", "staging", "cloud"],
                )
                .variable(
                    "organization",
                    "Organization name or UUID",
                    "00000000-0000-0000-0000-000000000000",
                )
                .variable(
                    "tenant",
                    "Tenant name or UUID",
                    "00000000-0000-0000-0000-000000000000",
                )
    )
```

I didn't find a very natural place to add tests for this, please let me know if there is a good place to do so.