### PR TITLE
refactor: middleware transform can take ownership

### DIFF
--- a/examples/grpc/middleware/src/middleware.rs
+++ b/examples/grpc/middleware/src/middleware.rs
@@ -8,7 +8,7 @@ pub(crate) struct ClientMiddleware;
 impl<E: Endpoint + 'static> Middleware<E> for ClientMiddleware {
     type Output = BoxEndpoint<'static, E::Output>;
 
-    fn transform(&self, ep: E) -> Self::Output {
+    fn transform(self, ep: E) -> Self::Output {
         ep.before(|req| async move {
             println!("client request: {}", req.uri().path());
             Ok(req)
@@ -22,7 +22,7 @@ pub(crate) struct ServerMiddleware;
 impl<E: Endpoint + 'static> Middleware<E> for ServerMiddleware {
     type Output = BoxEndpoint<'static, E::Output>;
 
-    fn transform(&self, ep: E) -> Self::Output {
+    fn transform(self, ep: E) -> Self::Output {
         ep.before(|req| async move {
             println!("handle request: {}", req.original_uri().path());
             Ok(req)

--- a/examples/poem/basic-auth/src/main.rs
+++ b/examples/poem/basic-auth/src/main.rs
@@ -17,7 +17,7 @@ struct BasicAuth {
 impl<E: Endpoint> Middleware<E> for BasicAuth {
     type Output = BasicAuthEndpoint<E>;
 
-    fn transform(&self, ep: E) -> Self::Output {
+    fn transform(self, ep: E) -> Self::Output {
         BasicAuthEndpoint {
             ep,
             username: self.username.clone(),

--- a/examples/poem/middleware/src/main.rs
+++ b/examples/poem/middleware/src/main.rs
@@ -8,7 +8,7 @@ struct Log;
 impl<E: Endpoint> Middleware<E> for Log {
     type Output = LogImpl<E>;
 
-    fn transform(&self, ep: E) -> Self::Output {
+    fn transform(self, ep: E) -> Self::Output {
         LogImpl(ep)
     }
 }

--- a/poem-derive/src/lib.rs
+++ b/poem-derive/src/lib.rs
@@ -164,7 +164,7 @@ pub fn generate_implement_middlewares(_: TokenStream) -> TokenStream {
             {
                 type Output = #output_type::Output;
 
-                fn transform(&self, ep: E) -> Self::Output {
+                fn transform(self, ep: E) -> Self::Output {
                     #(#transforms)*
                     ep
                 }

--- a/poem/src/middleware/add_data.rs
+++ b/poem/src/middleware/add_data.rs
@@ -19,7 +19,7 @@ where
 {
     type Output = AddDataEndpoint<E, T>;
 
-    fn transform(&self, ep: E) -> Self::Output {
+    fn transform(self, ep: E) -> Self::Output {
         AddDataEndpoint {
             inner: ep,
             value: self.value.clone(),

--- a/poem/src/middleware/catch_panic.rs
+++ b/poem/src/middleware/catch_panic.rs
@@ -114,7 +114,7 @@ impl<H> CatchPanic<H> {
 impl<E: Endpoint, H: PanicHandler> Middleware<E> for CatchPanic<H> {
     type Output = CatchPanicEndpoint<E, H>;
 
-    fn transform(&self, ep: E) -> Self::Output {
+    fn transform(self, ep: E) -> Self::Output {
         CatchPanicEndpoint {
             inner: ep,
             panic_handler: self.panic_handler.clone(),

--- a/poem/src/middleware/compression.rs
+++ b/poem/src/middleware/compression.rs
@@ -111,7 +111,7 @@ impl Compression {
 impl<E: Endpoint> Middleware<E> for Compression {
     type Output = CompressionEndpoint<E>;
 
-    fn transform(&self, ep: E) -> Self::Output {
+    fn transform(self, ep: E) -> Self::Output {
         CompressionEndpoint {
             ep,
             level: self.level,

--- a/poem/src/middleware/cookie_jar_manager.rs
+++ b/poem/src/middleware/cookie_jar_manager.rs
@@ -34,7 +34,7 @@ where
 {
     type Output = CookieJarManagerEndpoint<E>;
 
-    fn transform(&self, ep: E) -> Self::Output {
+    fn transform(self, ep: E) -> Self::Output {
         CookieJarManagerEndpoint {
             inner: ep,
             key: self.key.clone(),

--- a/poem/src/middleware/cors.rs
+++ b/poem/src/middleware/cors.rs
@@ -208,7 +208,7 @@ impl Cors {
 impl<E: Endpoint> Middleware<E> for Cors {
     type Output = CorsEndpoint<E>;
 
-    fn transform(&self, ep: E) -> Self::Output {
+    fn transform(self, ep: E) -> Self::Output {
         CorsEndpoint {
             inner: ep,
             allow_credentials: self.allow_credentials,

--- a/poem/src/middleware/csrf.rs
+++ b/poem/src/middleware/csrf.rs
@@ -177,7 +177,7 @@ impl Csrf {
 impl<E: Endpoint> Middleware<E> for Csrf {
     type Output = CookieJarManagerEndpoint<CsrfEndpoint<E>>;
 
-    fn transform(&self, ep: E) -> Self::Output {
+    fn transform(self, ep: E) -> Self::Output {
         CookieJarManager::new().transform(CsrfEndpoint {
             inner: ep,
             protect: Arc::new(AesGcmCsrfProtection::from_key(self.key)),

--- a/poem/src/middleware/force_https.rs
+++ b/poem/src/middleware/force_https.rs
@@ -44,7 +44,7 @@ where
 {
     type Output = ForceHttpsEndpoint<E>;
 
-    fn transform(&self, ep: E) -> Self::Output {
+    fn transform(self, ep: E) -> Self::Output {
         ForceHttpsEndpoint {
             inner: ep,
             https_port: self.https_port,

--- a/poem/src/middleware/mod.rs
+++ b/poem/src/middleware/mod.rs
@@ -74,7 +74,7 @@ use crate::endpoint::{EitherEndpoint, Endpoint};
 /// impl<E: Endpoint> Middleware<E> for TokenMiddleware {
 ///     type Output = TokenMiddlewareImpl<E>;
 ///
-///     fn transform(&self, ep: E) -> Self::Output {
+///     fn transform(self, ep: E) -> Self::Output {
 ///         TokenMiddlewareImpl { ep }
 ///     }
 /// }
@@ -180,7 +180,7 @@ pub trait Middleware<E: Endpoint> {
     type Output: Endpoint;
 
     /// Transform the input [`Endpoint`] to another one.
-    fn transform(&self, ep: E) -> Self::Output;
+    fn transform(self, ep: E) -> Self::Output;
 
     /// Create a new middleware by combining two middlewares.
     ///
@@ -296,16 +296,8 @@ impl<E: Endpoint> Middleware<E> for () {
     type Output = E;
 
     #[inline]
-    fn transform(&self, ep: E) -> Self::Output {
+    fn transform(self, ep: E) -> Self::Output {
         ep
-    }
-}
-
-impl<E: Endpoint, T: Middleware<E>> Middleware<E> for &T {
-    type Output = T::Output;
-
-    fn transform(&self, ep: E) -> Self::Output {
-        T::transform(self, ep)
     }
 }
 
@@ -325,7 +317,7 @@ where
     type Output = B::Output;
 
     #[inline]
-    fn transform(&self, ep: E) -> Self::Output {
+    fn transform(self, ep: E) -> Self::Output {
         self.b.transform(self.a.transform(ep))
     }
 }
@@ -362,7 +354,7 @@ where
     type Output = EitherEndpoint<A::Output, B::Output>;
 
     #[inline]
-    fn transform(&self, ep: E) -> Self::Output {
+    fn transform(self, ep: E) -> Self::Output {
         match self {
             EitherMiddleware::A(a, _) => EitherEndpoint::A(a.transform(ep)),
             EitherMiddleware::B(b, _) => EitherEndpoint::B(b.transform(ep)),
@@ -383,7 +375,7 @@ where
 {
     type Output = E2;
 
-    fn transform(&self, ep: E) -> Self::Output {
+    fn transform(self, ep: E) -> Self::Output {
         (self.0)(ep)
     }
 }

--- a/poem/src/middleware/normalize_path.rs
+++ b/poem/src/middleware/normalize_path.rs
@@ -62,7 +62,7 @@ impl NormalizePath {
 impl<E: Endpoint> Middleware<E> for NormalizePath {
     type Output = NormalizePathEndpoint<E>;
 
-    fn transform(&self, ep: E) -> Self::Output {
+    fn transform(self, ep: E) -> Self::Output {
         NormalizePathEndpoint {
             inner: ep,
             merge_slash: Regex::new("//+").unwrap(),

--- a/poem/src/middleware/opentelemetry_metrics.rs
+++ b/poem/src/middleware/opentelemetry_metrics.rs
@@ -50,7 +50,7 @@ impl OpenTelemetryMetrics {
 impl<E: Endpoint> Middleware<E> for OpenTelemetryMetrics {
     type Output = OpenTelemetryMetricsEndpoint<E>;
 
-    fn transform(&self, ep: E) -> Self::Output {
+    fn transform(self, ep: E) -> Self::Output {
         OpenTelemetryMetricsEndpoint {
             request_count: self.request_count.clone(),
             error_count: self.error_count.clone(),

--- a/poem/src/middleware/opentelemetry_tracing.rs
+++ b/poem/src/middleware/opentelemetry_tracing.rs
@@ -37,7 +37,7 @@ where
 {
     type Output = OpenTelemetryTracingEndpoint<T, E>;
 
-    fn transform(&self, ep: E) -> Self::Output {
+    fn transform(self, ep: E) -> Self::Output {
         OpenTelemetryTracingEndpoint {
             tracer: self.tracer.clone(),
             inner: ep,

--- a/poem/src/middleware/propagate_header.rs
+++ b/poem/src/middleware/propagate_header.rs
@@ -33,7 +33,7 @@ impl PropagateHeader {
 impl<E: Endpoint> Middleware<E> for PropagateHeader {
     type Output = PropagateHeaderEndpoint<E>;
 
-    fn transform(&self, ep: E) -> Self::Output {
+    fn transform(self, ep: E) -> Self::Output {
         PropagateHeaderEndpoint {
             inner: ep,
             headers: self.headers.clone(),

--- a/poem/src/middleware/requestid.rs
+++ b/poem/src/middleware/requestid.rs
@@ -63,7 +63,7 @@ impl Default for RequestId {
 
 impl<E: Endpoint> Middleware<E> for RequestId {
     type Output = RequestIdEndpoint<E>;
-    fn transform(&self, next: E) -> Self::Output {
+    fn transform(self, next: E) -> Self::Output {
         RequestIdEndpoint {
             next,
             header_name: self.header_name.clone(),

--- a/poem/src/middleware/sensitive_header.rs
+++ b/poem/src/middleware/sensitive_header.rs
@@ -75,7 +75,7 @@ impl SensitiveHeader {
 impl<E: Endpoint> Middleware<E> for SensitiveHeader {
     type Output = SensitiveHeaderEndpoint<E>;
 
-    fn transform(&self, ep: E) -> Self::Output {
+    fn transform(self, ep: E) -> Self::Output {
         SensitiveHeaderEndpoint {
             inner: ep,
             headers: self.headers.clone(),

--- a/poem/src/middleware/set_header.rs
+++ b/poem/src/middleware/set_header.rs
@@ -93,7 +93,7 @@ impl SetHeader {
 impl<E: Endpoint> Middleware<E> for SetHeader {
     type Output = SetHeaderEndpoint<E>;
 
-    fn transform(&self, ep: E) -> Self::Output {
+    fn transform(self, ep: E) -> Self::Output {
         SetHeaderEndpoint {
             inner: ep,
             actions: self.actions.clone(),

--- a/poem/src/middleware/size_limit.rs
+++ b/poem/src/middleware/size_limit.rs
@@ -24,7 +24,7 @@ impl SizeLimit {
 impl<E: Endpoint> Middleware<E> for SizeLimit {
     type Output = SizeLimitEndpoint<E>;
 
-    fn transform(&self, ep: E) -> Self::Output {
+    fn transform(self, ep: E) -> Self::Output {
         SizeLimitEndpoint {
             inner: ep,
             max_size: self.max_size,

--- a/poem/src/middleware/tokio_metrics_mw.rs
+++ b/poem/src/middleware/tokio_metrics_mw.rs
@@ -58,7 +58,7 @@ impl TokioMetrics {
 impl<E: Endpoint> Middleware<E> for TokioMetrics {
     type Output = TokioMetricsEndpoint<E>;
 
-    fn transform(&self, ep: E) -> Self::Output {
+    fn transform(self, ep: E) -> Self::Output {
         let monitor = TaskMonitor::new();
         let interval = self.interval;
         let metrics = self.metrics.clone();

--- a/poem/src/middleware/tower_compat.rs
+++ b/poem/src/middleware/tower_compat.rs
@@ -50,7 +50,7 @@ where
 {
     type Output = TowerServiceToEndpoint<L::Service>;
 
-    fn transform(&self, ep: E) -> Self::Output {
+    fn transform(self, ep: E) -> Self::Output {
         let new_svc = self.0.layer(EndpointToTowerService(Arc::new(ep)));
         let buffer = Buffer::new(new_svc, 32);
         TowerServiceToEndpoint(buffer)

--- a/poem/src/middleware/tracing_mw.rs
+++ b/poem/src/middleware/tracing_mw.rs
@@ -14,7 +14,7 @@ pub struct Tracing;
 impl<E: Endpoint> Middleware<E> for Tracing {
     type Output = TracingEndpoint<E>;
 
-    fn transform(&self, ep: E) -> Self::Output {
+    fn transform(self, ep: E) -> Self::Output {
         TracingEndpoint { inner: ep }
     }
 }

--- a/poem/src/route/router.rs
+++ b/poem/src/route/router.rs
@@ -639,7 +639,7 @@ mod tests {
     impl<E: Endpoint> crate::Middleware<E> for PathPatternSpy {
         type Output = PathPatternSpyEndpoint<E>;
 
-        fn transform(&self, ep: E) -> Self::Output {
+        fn transform(self, ep: E) -> Self::Output {
             PathPatternSpyEndpoint {
                 spy: self.clone(),
                 inner: ep,

--- a/poem/src/session/cookie_session.rs
+++ b/poem/src/session/cookie_session.rs
@@ -28,7 +28,7 @@ impl CookieSession {
 impl<E: Endpoint> Middleware<E> for CookieSession {
     type Output = CookieJarManagerEndpoint<CookieSessionEndpoint<E>>;
 
-    fn transform(&self, ep: E) -> Self::Output {
+    fn transform(self, ep: E) -> Self::Output {
         CookieJarManager::new().transform(CookieSessionEndpoint {
             inner: ep,
             config: self.config.clone(),

--- a/poem/src/session/server_session.rs
+++ b/poem/src/session/server_session.rs
@@ -28,7 +28,7 @@ impl<T> ServerSession<T> {
 impl<T: SessionStorage, E: Endpoint> Middleware<E> for ServerSession<T> {
     type Output = CookieJarManagerEndpoint<ServerSessionEndpoint<T, E>>;
 
-    fn transform(&self, ep: E) -> Self::Output {
+    fn transform(self, ep: E) -> Self::Output {
         CookieJarManager::new().transform(ServerSessionEndpoint {
             inner: ep,
             config: self.config.clone(),


### PR DESCRIPTION
This is a breaking change. But since we always use `middleware.transform` exactly once, take the ownership can reduce some unnecessary wrapper.

For example, a middleware can take an owned value, but since `transform` use `&self`, when decorate `endpoint`, you can only pass a ref of that owned value, or copy, or Arc(Mutex).

cc @sunli829 what do you think?