### PR TITLE
Support rename in NewType

### DIFF
--- a/poem-openapi/src/docs/newtype.md
+++ b/poem-openapi/src/docs/newtype.md
@@ -11,6 +11,7 @@ Define a new type.
 | to_header      | Implement `ToHeader` trait. Default is `true`                | bool   | Y        |
 | external_docs  | Specify a external resource for extended documentation       | string | Y        |
 | example        | Indicates that the type has implemented `Example` trait      | bool   | Y        |
+| rename         | Rename the type                                              | string | Y        |
 
 # Examples
 

--- a/poem-openapi/tests/newtype.rs
+++ b/poem-openapi/tests/newtype.rs
@@ -61,3 +61,12 @@ async fn generic() {
         Some("string")
     );
 }
+
+#[tokio::test]
+async fn rename_new_type() {
+    #[derive(NewType)]
+    #[oai(rename = "TYPE_A")]
+    struct TypeA(String);
+
+    assert_eq!(TypeA::name(), "TYPE_A");
+}

--- a/poem-openapi/tests/newtype.rs
+++ b/poem-openapi/tests/newtype.rs
@@ -70,3 +70,14 @@ async fn rename_new_type() {
 
     assert_eq!(TypeA::name(), "TYPE_A");
 }
+
+#[tokio::test]
+async fn rename_new_type_using_const() {
+    const NEW_NAME: &str = "NEW_NAME";
+
+    #[derive(NewType)]
+    #[oai(rename = NEW_NAME)]
+    struct TypeA(String);
+
+    assert_eq!(TypeA::name(), NEW_NAME);
+}


### PR DESCRIPTION
Parametrizing a generic object with two different `NewType`s that have the same inner type leads to a name clash at runtime. This merge request adds a rename parameter to override the default NewType names.

```rust
#[derive(NewType)]
struct NewTypeA(String);

#[derive(NewType)]
struct NewTypeB(String);

#[derive(Debug, Clone, Object)]
pub struct Wrapper<T>
where
    T: Type + ParseFromJSON + ToJSON,
{
    pub id: T,
}

// name clash
assert_eq!(Wrapper::<NewTypeA>::name(), Wrapper::<NewTypeB>::name()); 
```