### PR TITLE
Define a range of response codes

### DIFF
--- a/examples/openapi/content-type-accept/src/bcs_payload.rs
+++ b/examples/openapi/content-type-accept/src/bcs_payload.rs
@@ -84,6 +84,7 @@ impl<T: Serialize + Type> ApiResponse for Bcs<T> {
             responses: vec![MetaResponse {
                 description: "",
                 status: Some(200),
+                status_range: None,
                 content: vec![MetaMediaType {
                     content_type: Self::CONTENT_TYPE,
                     schema: Self::schema_ref(),

--- a/examples/openapi/custom-payload/src/bcs_payload.rs
+++ b/examples/openapi/custom-payload/src/bcs_payload.rs
@@ -84,6 +84,7 @@ impl<T: Serialize + Type> ApiResponse for Bcs<T> {
             responses: vec![MetaResponse {
                 description: "",
                 status: Some(200),
+                status_range: None,
                 content: vec![MetaMediaType {
                     content_type: Self::CONTENT_TYPE,
                     schema: Self::schema_ref(),

--- a/poem-openapi/src/base.rs
+++ b/poem-openapi/src/base.rs
@@ -331,6 +331,7 @@ impl ApiResponse for () {
             responses: vec![MetaResponse {
                 description: "",
                 status: Some(200),
+                status_range: None,
                 content: vec![],
                 headers: vec![],
             }],
@@ -384,6 +385,7 @@ where
             responses: vec![MetaResponse {
                 description: "A websocket response",
                 status: Some(101),
+                status_range: None,
                 content: vec![],
                 headers: vec![],
             }],

--- a/poem-openapi/src/docs/response.md
+++ b/poem-openapi/src/docs/response.md
@@ -13,6 +13,7 @@ Define an OpenAPI response.
 | Attribute    | description                                                  | Type                                                       | Optional |
 |--------------|--------------------------------------------------------------|------------------------------------------------------------|----------|
 | status       | HTTP status code. If omitted, it is a default response type. | u16                                                        | Y        |
+| status_range | Specify a range of HTTP status codes.                        | string                                                     | Y        |
 | content_type | Specify the content type.                                    | string                                                     | Y        |
 | actual_type  | Specifies the actual response type                           | string                                                     | Y        |
 | header       | Add an extra header                                          | [`ExtraHeader`](macro@ApiResponse#extra-header-parameters) | Y        |
@@ -59,6 +60,23 @@ use poem_openapi::ApiResponse;
 enum CreateUserResponse {
     #[oai(status = 200, header(name = "X-ExtraHeader-3", ty = "f32"))]
     Ok,
+}
+```
+
+# Example status range
+
+```rust
+use poem::http::StatusCode;
+use poem_openapi::{payload::PlainText, ApiResponse};
+
+#[derive(ApiResponse)]
+enum CreateUserResponse {
+    #[oai(status_range = "2XX")]
+    Ok(StatusCode, PlainText<String>),
+    #[oai(status_range = "4XX")]
+    ClientError(StatusCode),
+    #[oai(status_range = "5XX")]
+    ServerError(StatusCode),
 }
 ```
 

--- a/poem-openapi/src/payload/attachment.rs
+++ b/poem-openapi/src/payload/attachment.rs
@@ -104,6 +104,7 @@ impl<T: Into<Body> + Send> ApiResponse for Attachment<T> {
             responses: vec![MetaResponse {
                 description: "",
                 status: Some(200),
+                status_range: None,
                 content: vec![MetaMediaType {
                     content_type: Self::CONTENT_TYPE,
                     schema: Self::schema_ref(),

--- a/poem-openapi/src/payload/base64_payload.rs
+++ b/poem-openapi/src/payload/base64_payload.rs
@@ -149,6 +149,7 @@ impl<T: AsRef<[u8]> + Send> ApiResponse for Base64<T> {
             responses: vec![MetaResponse {
                 description: "",
                 status: Some(200),
+                status_range: None,
                 content: vec![MetaMediaType {
                     content_type: Self::CONTENT_TYPE,
                     schema: Self::schema_ref(),

--- a/poem-openapi/src/payload/binary.rs
+++ b/poem-openapi/src/payload/binary.rs
@@ -141,6 +141,7 @@ impl<T: Into<Body> + Send> ApiResponse for Binary<T> {
             responses: vec![MetaResponse {
                 description: "",
                 status: Some(200),
+                status_range: None,
                 content: vec![MetaMediaType {
                     content_type: Self::CONTENT_TYPE,
                     schema: Self::schema_ref(),

--- a/poem-openapi/src/payload/event_stream.rs
+++ b/poem-openapi/src/payload/event_stream.rs
@@ -117,6 +117,7 @@ impl<T: Stream<Item = E> + Send + 'static, E: Type + ToJSON> ApiResponse for Eve
             responses: vec![MetaResponse {
                 description: "",
                 status: Some(200),
+                status_range: None,
                 content: vec![MetaMediaType {
                     content_type: Self::CONTENT_TYPE,
                     schema: Self::schema_ref(),

--- a/poem-openapi/src/payload/html.rs
+++ b/poem-openapi/src/payload/html.rs
@@ -63,6 +63,7 @@ impl<T: Into<String> + Send> ApiResponse for Html<T> {
             responses: vec![MetaResponse {
                 description: "",
                 status: Some(200),
+                status_range: None,
                 content: vec![MetaMediaType {
                     content_type: Self::CONTENT_TYPE,
                     schema: Self::schema_ref(),

--- a/poem-openapi/src/payload/json.rs
+++ b/poem-openapi/src/payload/json.rs
@@ -82,6 +82,7 @@ impl<T: ToJSON> ApiResponse for Json<T> {
             responses: vec![MetaResponse {
                 description: "",
                 status: Some(200),
+                status_range: None,
                 content: vec![MetaMediaType {
                     content_type: Self::CONTENT_TYPE,
                     schema: Self::schema_ref(),

--- a/poem-openapi/src/payload/plain_text.rs
+++ b/poem-openapi/src/payload/plain_text.rs
@@ -63,6 +63,7 @@ impl<T: Into<String> + Send> ApiResponse for PlainText<T> {
             responses: vec![MetaResponse {
                 description: "",
                 status: Some(200),
+                status_range: None,
                 content: vec![MetaMediaType {
                     content_type: Self::CONTENT_TYPE,
                     schema: Self::schema_ref(),

--- a/poem-openapi/src/payload/xml.rs
+++ b/poem-openapi/src/payload/xml.rs
@@ -84,6 +84,7 @@ impl<T: ToXML> ApiResponse for Xml<T> {
             responses: vec![MetaResponse {
                 description: "",
                 status: Some(200),
+                status_range: None,
                 content: vec![MetaMediaType {
                     content_type: Self::CONTENT_TYPE,
                     schema: Self::schema_ref(),

--- a/poem-openapi/src/payload/yaml.rs
+++ b/poem-openapi/src/payload/yaml.rs
@@ -82,6 +82,7 @@ impl<T: ToYAML> ApiResponse for Yaml<T> {
             responses: vec![MetaResponse {
                 description: "",
                 status: Some(200),
+                status_range: None,
                 content: vec![MetaMediaType {
                     content_type: Self::CONTENT_TYPE,
                     schema: Self::schema_ref(),

--- a/poem-openapi/src/registry/mod.rs
+++ b/poem-openapi/src/registry/mod.rs
@@ -428,6 +428,8 @@ pub struct MetaResponse {
     pub description: &'static str,
     #[serde(skip)]
     pub status: Option<u16>,
+    #[serde(skip)]
+    pub status_range: Option<String>,
     #[serde(
         skip_serializing_if = "Vec::is_empty",
         serialize_with = "serialize_content"

--- a/poem-openapi/src/registry/ser.rs
+++ b/poem-openapi/src/registry/ser.rs
@@ -57,7 +57,10 @@ impl Serialize for MetaResponses {
         for resp in &self.responses {
             match resp.status {
                 Some(status) => s.serialize_entry(&format!("{status}"), resp)?,
-                None => s.serialize_entry("default", resp)?,
+                None => match &resp.status_range {
+                    Some(status_range) => s.serialize_entry(&format!("{status_range}"), resp)?,
+                    None => s.serialize_entry("default", resp)?,
+                },
             }
         }
         s.end()

--- a/poem-openapi/src/response/static_file.rs
+++ b/poem-openapi/src/response/static_file.rs
@@ -18,6 +18,7 @@ impl ApiResponse for StaticFileResponse {
                 MetaResponse {
                     description: "",
                     status: Some(200),
+                    status_range: None,
                     content: vec![MetaMediaType {
                         content_type: Binary::<Body>::CONTENT_TYPE,
                         schema: Binary::<Body>::schema_ref(),
@@ -45,35 +46,41 @@ impl ApiResponse for StaticFileResponse {
                 MetaResponse {
                     description: "Not modified",
                     status: Some(304),
+                    status_range: None,
                     content: vec![],
                     headers: vec![],
                 },
                 MetaResponse {
                     description: "Bad request",
                     status: Some(400),
+                    status_range: None,
                     content: vec![],
                     headers: vec![],
                 },
                 MetaResponse {
                     description: "Resource was not found",
                     status: Some(404),
+                    status_range: None,
                     content: vec![],
                     headers: vec![],
                 },
                 MetaResponse {
                     description: "Precondition failed",
                     status: Some(412),
+                    status_range: None,
                     content: vec![],
                     headers: vec![],
                 },
                 MetaResponse {
                     description: "The Content-Range response HTTP header indicates where in a full body message a partial message belongs.",
                     status: Some(416),
+                    status_range: None,
                     content: vec![],
                     headers: vec![],
                 }, MetaResponse {
                     description: "Internal server error",
                     status: Some(500),
+                    status_range: None,
                     content: vec![],
                     headers: vec![],
                 },

--- a/poem-openapi/tests/response.rs
+++ b/poem-openapi/tests/response.rs
@@ -50,12 +50,14 @@ fn meta() {
                 MetaResponse {
                     description: "Ok",
                     status: Some(200),
+                    status_range: None,
                     content: vec![],
                     headers: vec![]
                 },
                 MetaResponse {
                     description: "A\nB\n\nC",
                     status: Some(400),
+                    status_range: None,
                     content: vec![MetaMediaType {
                         content_type: "application/json; charset=utf-8",
                         schema: MetaSchemaRef::Reference("BadRequestResult".to_string())
@@ -65,6 +67,7 @@ fn meta() {
                 MetaResponse {
                     description: "yaml response",
                     status: Some(400),
+                    status_range: None,
                     content: vec![MetaMediaType {
                         content_type: "application/yaml; charset=utf-8",
                         schema: MetaSchemaRef::Reference("BadRequestResult".to_string())
@@ -74,6 +77,7 @@ fn meta() {
                 MetaResponse {
                     description: "",
                     status: None,
+                    status_range: None,
                     content: vec![MetaMediaType {
                         content_type: "text/plain; charset=utf-8",
                         schema: MetaSchemaRef::Inline(Box::new(MetaSchema::new("string"))),
@@ -271,6 +275,7 @@ async fn generic() {
             responses: vec![MetaResponse {
                 description: "",
                 status: Some(200),
+                status_range: None,
                 content: vec![MetaMediaType {
                     content_type: "application/json; charset=utf-8",
                     schema: MetaSchemaRef::Inline(Box::new(MetaSchema::new("string")))
@@ -305,6 +310,7 @@ async fn item_content_type() {
                 MetaResponse {
                     description: "",
                     status: Some(200),
+                    status_range: None,
                     content: vec![MetaMediaType {
                         content_type: "application/json2",
                         schema: MetaSchemaRef::Inline(Box::new(MetaSchema::new_with_format(
@@ -316,6 +322,7 @@ async fn item_content_type() {
                 MetaResponse {
                     description: "",
                     status: None,
+                    status_range: None,
                     content: vec![MetaMediaType {
                         content_type: "application/json3",
                         schema: MetaSchemaRef::Inline(Box::new(MetaSchema::new_with_format(

--- a/poem-openapi/tests/response_content.rs
+++ b/poem-openapi/tests/response_content.rs
@@ -63,6 +63,7 @@ async fn use_in_api_response() {
             responses: vec![MetaResponse {
                 description: "",
                 status: Some(200),
+                status_range: None,
                 content: MyResponseContent::media_types(),
                 headers: vec![]
             }]

--- a/poem-openapi/tests/webhook.rs
+++ b/poem-openapi/tests/webhook.rs
@@ -179,6 +179,7 @@ async fn response() {
             responses: vec![MetaResponse {
                 description: "",
                 status: Some(200),
+                status_range: None,
                 content: vec![MetaMediaType {
                     content_type: "application/json; charset=utf-8",
                     schema: i32::schema_ref(),


### PR DESCRIPTION
This makes it possible to define a range of response codes, like this:

```rust
use poem::http::StatusCode;
use poem_openapi::{payload::PlainText, ApiResponse};

#[derive(ApiResponse)]
enum CreateUserResponse {
    #[oai(status_range = "2XX")]
    Ok(StatusCode, PlainText<String>),
    #[oai(status_range = "4XX")]
    ClientError(StatusCode),
    #[oai(status_range = "5XX")]
    ServerError(StatusCode),
}
```

The inner `StatusCode` will be used to set the status code of the actual response.

The range syntax is defined in the [official specification](https://github.com/OAI/OpenAPI-Specification/blob/8e3015a1c549375dd64395606cf8f991b0aabbd5/versions/3.1.1.md#patterned-fields-1) as follows:

> To define a range of response codes, this field MAY contain the uppercase wildcard character `X`. For example, `2XX` represents all response codes between `200` and `299`. Only the following range definitions are allowed: `1XX`, `2XX`, `3XX`, `4XX`, and `5XX`.

Closes https://github.com/poem-web/poem/issues/965.