### PR TITLE
Update CI badge in README to show only `master`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
   <!-- CI -->
-  <img src="https://github.com/poem-web/poem/workflows/CI/badge.svg?branch=master" />
+  <img src="https://github.com/poem-web/poem/actions/workflows/ci.yml/badge.svg" />
   <!-- codecov -->
   <img src="https://codecov.io/gh/poem-web/poem/branch/master/graph/badge.svg" />
   <a href="https://github.com/rust-secure-code/safety-dance/">

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
   <!-- CI -->
-  <img src="https://github.com/poem-web/poem/workflows/CI/badge.svg" />
+  <img src="https://github.com/poem-web/poem/workflows/CI/badge.svg?branch=master" />
   <!-- codecov -->
   <img src="https://codecov.io/gh/poem-web/poem/branch/master/graph/badge.svg" />
   <a href="https://github.com/rust-secure-code/safety-dance/">


### PR DESCRIPTION
Previously, this was showing the CI state for *any* branch, which meant that whatever CI run happened to go most recently would be the status reported by the badge. Using [the branch parameter][docs] to use only the `master` branch going forward will provide a more accurate picture to folks looking at the project.

[docs]: https://github.com/github/docs/blob/main/content/actions/monitoring-and-troubleshooting-workflows/monitoring-workflows/adding-a-workflow-status-badge.md#using-the-branch-parameter