### PR TITLE
Fix missing condition for Stoplight Elements UI

### DIFF
--- a/poem-openapi/src/lib.rs
+++ b/poem-openapi/src/lib.rs
@@ -142,10 +142,11 @@ mod base;
 mod openapi;
 mod path_util;
 #[cfg(any(
-    feature = "swagger-ui",
+    feature = "openapi-explorer",
     feature = "rapidoc",
     feature = "redoc",
-    feature = "openapi-explorer"
+    feature = "stoplight-elements",
+    feature = "swagger-ui",
 ))]
 mod ui;
 


### PR DESCRIPTION
This PR adds the missing condition for mod ui in lib.rs to ensure that stoplight-elements-ui is properly included when enabled.

Previously, mod ui was only included when one of the following features was enabled:
- swagger-ui
- rapidoc
- redoc
- openapi-explorer

However, stoplight-elements-ui was missing from this condition, causing it to be excluded unless one of the other features was also enabled.

Thank you, https://github.com/poem-web/poem/pull/954?new_mergebox=true#issuecomment-2661711927