### PR TITLE
feat: add `Partitioned` option for `CookieConfig`

### DIFF
--- a/poem/src/session/cookie_config.rs
+++ b/poem/src/session/cookie_config.rs
@@ -26,6 +26,7 @@ pub struct CookieConfig {
     http_only: bool,
     max_age: Option<Duration>,
     same_site: Option<SameSite>,
+    partitioned: bool,
 }
 
 impl Default for CookieConfig {
@@ -39,6 +40,7 @@ impl Default for CookieConfig {
             http_only: true,
             max_age: None,
             same_site: None,
+            partitioned: false,
         }
     }
 }
@@ -119,6 +121,15 @@ impl CookieConfig {
         }
     }
 
+    /// Sets the `Partitioned` to the session cookie. Default is `false`.
+    #[must_use]
+    pub fn partitioned(self, value: bool) -> Self {
+        Self {
+            partitioned: value,
+            ..self
+        }
+    }
+
     /// Sets the `MaxAge` to the session cookie.
     #[must_use]
     pub fn max_age(self, value: impl Into<Option<Duration>>) -> Self {
@@ -152,6 +163,7 @@ impl CookieConfig {
         }
 
         cookie.set_same_site(self.same_site);
+        cookie.set_partitioned(self.partitioned);
 
         match &self.security {
             CookieSecurity::Plain => cookie_jar.add(cookie),

--- a/poem/src/web/cookie.rs
+++ b/poem/src/web/cookie.rs
@@ -233,6 +233,20 @@ impl Cookie {
         self.0.secure().unwrap_or_default()
     }
 
+    /// Returns whether this cookie was marked `Partitioned` or not.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use poem::web::cookie::Cookie;
+    ///
+    /// let cookie = Cookie::parse("foo=bar; Partitioned").unwrap();
+    /// assert!(cookie.partitioned());
+    /// ```
+    pub fn partitioned(&self) -> bool {
+        self.0.partitioned().unwrap_or_default()
+    }
+
     /// Sets the `domain` of `self` to `domain`.
     pub fn set_domain(&mut self, domain: impl Into<String>) {
         self.0.set_domain(domain.into());
@@ -276,6 +290,11 @@ impl Cookie {
     /// Sets the value of `Secure` in `self` to `value`.
     pub fn set_secure(&mut self, value: impl Into<Option<bool>>) {
         self.0.set_secure(value);
+    }
+
+    /// Sets the value of `Partitioned` in `self` to `value`.
+    pub fn set_partitioned(&mut self, value: impl Into<Option<bool>>) {
+        self.0.set_partitioned(value);
     }
 
     /// Sets the value of `self` to `value`.


### PR DESCRIPTION
### Summary

This commit adds the `Partitioned` option to the `CookieConfig` object in the built-in Session support of poem.

### Background

Third-party cookies may soon be restricted by Chromium-based browsers (https://goo.gle/3pc-dev-issue). These browsers require developers to use "Cookies Having Independent Partitioned State (CHIPS)" (https://developer.mozilla.org/en-US/docs/Web/Privacy/Privacy_sandbox/Partitioned_cookies), which involves adding the `Partitioned` attribute in `Set-Cookie`. As a result, developers using poem to build applications may need to use the `Partitioned` option in cookies.