### PR TITLE
fix(openapi): do not use `cookie` feature by default

### DIFF
--- a/poem-openapi/Cargo.toml
+++ b/poem-openapi/Cargo.toml
@@ -25,13 +25,13 @@ static-files = ["poem/static-files"]
 websocket = ["poem/websocket"]
 geo = ["dep:geo-types", "dep:geojson"]
 sonic-rs = ["poem/sonic-rs"]
+cookie = ["poem/cookie"]
 
 [dependencies]
 poem-openapi-derive.workspace = true
 poem = { workspace = true, default-features = true, features = [
   "multipart",
   "tempfile",
-  "cookie",
   "sse",
   "xml",
   "yaml",


### PR DESCRIPTION
I do not use this feature, and it's the only thing that pulls in `chrono` in my project. Is it really needed for `poem-openapi` to work?