### PR TITLE
fix: guard cookie features behind feature toggle

### DIFF
--- a/poem-openapi/src/auth/api_key.rs
+++ b/poem-openapi/src/auth/api_key.rs
@@ -32,6 +32,7 @@ impl ApiKeyAuthorization for ApiKey {
                     key: value.to_string(),
                 })
                 .ok_or_else(|| AuthorizationError.into()),
+            #[cfg(feature = "cookie")]
             MetaParamIn::Cookie => req
                 .cookie()
                 .get(name)

--- a/poem-openapi/src/param/mod.rs
+++ b/poem-openapi/src/param/mod.rs
@@ -1,9 +1,11 @@
 //! Parameter types for the API operation.
+#[cfg(feature = "cookie")]
 mod cookie;
 mod header;
 mod path;
 mod query;
 
+#[cfg(feature = "cookie")]
 pub use cookie::{Cookie, CookiePrivate, CookieSigned};
 pub use header::Header;
 pub use path::Path;

--- a/poem-openapi/tests/operation_param.rs
+++ b/poem-openapi/tests/operation_param.rs
@@ -1,10 +1,13 @@
+use poem::test::TestClient;
+#[cfg(feature = "cookie")]
 use poem::{
     http::header,
-    test::TestClient,
     web::cookie::{Cookie, CookieJar, CookieKey},
 };
+#[cfg(feature = "cookie")]
+use poem_openapi::param::{Cookie as ParamCookie, CookiePrivate, CookieSigned};
 use poem_openapi::{
-    param::{Cookie as ParamCookie, CookiePrivate, CookieSigned, Header, Path, Query},
+    param::{Header, Path, Query},
     registry::{MetaApi, MetaParamIn, MetaSchema, MetaSchemaRef},
     types::Type,
     OpenApi, OpenApiService,
@@ -261,6 +264,7 @@ async fn path() {
         .assert_status_is_ok();
 }
 
+#[cfg(feature = "cookie")]
 #[tokio::test]
 async fn cookie() {
     struct Api;
@@ -301,6 +305,7 @@ async fn cookie() {
         .assert_status_is_ok();
 }
 
+#[cfg(feature = "cookie")]
 #[tokio::test]
 async fn cookie_default() {
     struct Api;
@@ -579,6 +584,7 @@ async fn header_rename() {
         .assert_status_is_ok();
 }
 
+#[cfg(feature = "cookie")]
 #[tokio::test]
 async fn cookie_rename() {
     struct Api;

--- a/poem-openapi/tests/security_scheme.rs
+++ b/poem-openapi/tests/security_scheme.rs
@@ -1,10 +1,6 @@
-use poem::{
-    error::ResponseError,
-    http::{header, StatusCode},
-    test::TestClient,
-    web::{cookie::Cookie, headers},
-    Request,
-};
+use poem::{error::ResponseError, http::StatusCode, test::TestClient, web::headers, Request};
+#[cfg(feature = "cookie")]
+use poem::{http::header, web::cookie::Cookie};
 use poem_openapi::{
     auth::{ApiKey, Basic, Bearer},
     payload::PlainText,
@@ -275,16 +271,19 @@ async fn api_key_auth() {
     resp.assert_status_is_ok();
     resp.assert_text("abcdef").await;
 
-    let resp = cli
-        .get("/cookie")
-        .header(
-            header::COOKIE,
-            Cookie::new_with_str("key", "abcdef").to_string(),
-        )
-        .send()
-        .await;
-    resp.assert_status_is_ok();
-    resp.assert_text("abcdef").await;
+    #[cfg(feature = "cookie")]
+    {
+        let resp = cli
+            .get("/cookie")
+            .header(
+                header::COOKIE,
+                Cookie::new_with_str("key", "abcdef").to_string(),
+            )
+            .send()
+            .await;
+        resp.assert_status_is_ok();
+        resp.assert_text("abcdef").await;
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
I'm not sure why CI is happy, but running `cargo test` fails to compile on master, and presumably I broke it in https://github.com/poem-web/poem/pull/986.

With the feature gates added here, both `cargo test` and `cargo test -F cookie` passes on my machine