### PR TITLE
`from_request()` error handling

### DIFF
--- a/poem-openapi/Cargo.toml
+++ b/poem-openapi/Cargo.toml
@@ -35,6 +35,7 @@ poem = { workspace = true, default-features = true, features = [
   "sse",
   "xml",
   "yaml",
+  "cookie"
 ] }
 
 tokio = { workspace = true, features = ["fs"] }


### PR DESCRIPTION
## `explode = false` panic
we have an issue in our servers that has prevented us from using `explode = false` to accept array parameters in routes.

when a request was made missing some expected query parameters with `explode = false`, the request would panic on the second `.unwrap()` call in the previous version of `from_request`.

this adds some basic error handling around that scenario to prevent runtime panics.

### `"cookie"` feature change
i'm not sure why, this was just necessary to get it building. unrelated to the real change. seems to be an issue on master as well.