### PR TITLE
chore: add track_caller to test asserts

### DIFF
--- a/poem/src/test/json.rs
+++ b/poem/src/test/json.rs
@@ -28,6 +28,7 @@ macro_rules! impl_assert_types {
     ($($(#[$docs:meta])* ($ty:ty, $name:ident, $method:ident)),*) => {
         $(
         $(#[$docs])*
+        #[track_caller]
         pub fn $name(&self, value: $ty) {
             assert_eq!(self.$method(), value);
         }
@@ -50,6 +51,7 @@ macro_rules! impl_assert_array_types {
     ($($(#[$docs:meta])* ($ty:ty, $name:ident, $method:ident)),*) => {
         $(
         $(#[$docs])*
+        #[track_caller]
         pub fn $name(&self, values: &[$ty]) {
             assert_eq!(self.$method(), values);
         }
@@ -105,11 +107,13 @@ impl<'a> TestJsonValue<'a> {
     );
 
     /// Asserts that value is `float` and it equals to `value`.
+    #[track_caller]
     pub fn assert_f64(&self, value: f64) {
         assert!((self.f64() - value).abs() < f64::EPSILON);
     }
 
     /// Asserts that value is `float` array and it equals to `values`.
+    #[track_caller]
     pub fn assert_f64_array(&self, values: &[f64]) {
         assert!(self
             .f64_array()
@@ -145,11 +149,13 @@ impl<'a> TestJsonValue<'a> {
     }
 
     /// Asserts that the value is null.
+    #[track_caller]
     pub fn assert_null(&self) {
         assert!(self.0.is_null())
     }
 
     /// Asserts that the value is not null.
+    #[track_caller]
     pub fn assert_not_null(&self) {
         assert!(!self.0.is_null())
     }
@@ -202,22 +208,26 @@ impl<'a> TestJsonArray<'a> {
     }
 
     /// Asserts the array length is equals to `len`.
+    #[track_caller]
     pub fn assert_len(&self, len: usize) {
         assert_eq!(self.len(), len);
     }
 
     /// Asserts the array is empty.
+    #[track_caller]
     pub fn assert_is_empty(&self) {
         assert!(self.is_empty());
     }
 
     /// Asserts the array contains values that satisfies a predicate.
+    #[track_caller]
     pub fn assert_contains(&self, f: impl FnMut(TestJsonValue<'_>) -> bool) {
         assert!(self.0.iter().map(TestJsonValue).any(f));
     }
 
     /// Asserts the array contains exactly one value that satisfies a
     /// predicate.
+    #[track_caller]
     pub fn assert_contains_exactly_one(&self, f: impl Fn(TestJsonValue<'_>) -> bool) {
         assert_eq!(
             self.0
@@ -264,11 +274,13 @@ impl<'a> TestJsonObject<'a> {
     }
 
     /// Asserts the object length is equals to `len`.
+    #[track_caller]
     pub fn assert_len(&self, len: usize) {
         assert_eq!(self.len(), len);
     }
 
     /// Asserts the object is empty.
+    #[track_caller]
     pub fn assert_is_empty(&self) {
         assert!(self.is_empty());
     }

--- a/poem/src/test/response.rs
+++ b/poem/src/test/response.rs
@@ -17,16 +17,19 @@ impl TestResponse {
     }
 
     /// Asserts that the status code is equals to `status`.
+    #[track_caller]
     pub fn assert_status(&self, status: StatusCode) {
         assert_eq!(self.0.status(), status);
     }
 
     /// Asserts that the status code is `200 OK`.
+    #[track_caller]
     pub fn assert_status_is_ok(&self) {
         self.assert_status(StatusCode::OK);
     }
 
     /// Asserts that header `key` is not exist.
+    #[track_caller]
     pub fn assert_header_is_not_exist<K>(&self, key: K)
     where
         K: TryInto<HeaderName>,
@@ -36,6 +39,7 @@ impl TestResponse {
     }
 
     /// Asserts that header `key` exist.
+    #[track_caller]
     pub fn assert_header_exist<K>(&self, key: K)
     where
         K: TryInto<HeaderName>,
@@ -45,6 +49,7 @@ impl TestResponse {
     }
 
     /// Asserts that header `key` is equals to `value`.
+    #[track_caller]
     pub fn assert_header<K, V>(&self, key: K, value: V)
     where
         K: TryInto<HeaderName>,
@@ -66,6 +71,7 @@ impl TestResponse {
     }
 
     /// Asserts that the header `key` is equal to `values` separated by commas.
+    #[track_caller]
     pub fn assert_header_csv<K, V, I>(&self, key: K, values: I)
     where
         K: TryInto<HeaderName>,
@@ -95,6 +101,7 @@ impl TestResponse {
     }
 
     /// Asserts that header `key` is equals to `values`.
+    #[track_caller]
     pub fn assert_header_all<K, V, I>(&self, key: K, values: I)
     where
         K: TryInto<HeaderName>,
@@ -126,6 +133,7 @@ impl TestResponse {
     }
 
     /// Asserts that content type is equals to `content_type`.
+    #[track_caller]
     pub fn assert_content_type(&self, content_type: &str) {
         self.assert_header(header::CONTENT_TYPE, content_type);
     }


### PR DESCRIPTION
This PR adds the `track_caller` attribute to synchronous test assertions, so errors point to the test call site instead of the library's code. Since `track_caller` isn't supported for async methods, this at least improves error reporting for sync assertions, making debugging easier.