### PR TITLE
feat(grpc-build): allow calling prost's `external_path` function

### DIFF
--- a/poem-grpc-build/src/config.rs
+++ b/poem-grpc-build/src/config.rs
@@ -300,6 +300,16 @@ impl Config {
         self
     }
 
+    /// Declare an externally provided Protobuf package or type.
+    pub fn extern_path<P1, P2>(mut self, proto_path: P1, rust_path: P2) -> Self
+    where
+        P1: Into<String>,
+        P2: Into<String>,
+    {
+        self.prost_config.extern_path(proto_path, rust_path);
+        self
+    }
+
     /// Enable or disable gRPC client code generation.
     pub fn build_client(mut self, enable: bool) -> Self {
         self.grpc_config.build_client = enable;


### PR DESCRIPTION
This is a follow up to #1016 which allows for serialization of `prost-wkt-types`.

In order to use the `Timestamp` type, you have to use add the following code to the `build.rs` (see https://github.com/tokio-rs/prost/issues/672):
```rust
        .extern_path(".google.protobuf.Timestamp", "::prost_wkt_types::Timestamp")
```
which is not possible in current `poem-grpc-build` config.