### PR TITLE
Fix webhook nesting

### DIFF
--- a/poem-openapi/src/docs/webhook.md
+++ b/poem-openapi/src/docs/webhook.md
@@ -17,6 +17,16 @@ Define an OpenAPI webhooks.
 | tag           | Operation tag                                                                                                        | Tags   | Y        |
 | operation_id  | Unique string used to identify the operation.                                                                        | string | Y        |
 
+# Doc Parameters
+
+The following attributes are parsed from the Rust documentation of the method.
+
+| Attribute | Description                      | Type   | Optional |
+|-----------|----------------------------------|--------|----------|
+| summary       | Define the summary of the operation. | string | Y        |
+| description       | Define the description of the operation. | string | Y        |
+
+
 # Operation argument parameters
 
 | Attribute                | Description                                                                                                                                                                                                                                           | Type                                      | Optional          |
@@ -50,6 +60,9 @@ struct Pet {
 
 #[Webhook]
 trait MyWebhooks {
+    /// This is the summary of the operation
+    ///
+    /// This is the description of the operation
     #[oai(method = "post")]
     fn new_pet(&self, pet: Json<Pet>);
 }

--- a/poem-openapi/src/registry/ser.rs
+++ b/poem-openapi/src/registry/ser.rs
@@ -73,7 +73,12 @@ impl Serialize for WebhookMap<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut s = serializer.serialize_map(Some(self.0.len()))?;
         for webhook in self.0 {
-            s.serialize_entry(&webhook.name, &webhook.operation)?;
+            let mut inner_map = BTreeMap::new();
+            inner_map.insert(
+                webhook.operation.method.to_string().to_lowercase(),
+                &webhook.operation,
+            );
+            s.serialize_entry(&webhook.name, &inner_map)?;
         }
         s.end()
     }


### PR DESCRIPTION
The generation of webhook metadata is not according to the specs. Here is an example of a spec compliant webhook method:

``` yaml
webhooks:
  newPet:
    post:
      requestBody:
     ...
```

Whereas the current poem implementation generates this:

```yaml
webhooks:
  newPet:
    requestBody:
```

E.g. it omits the `method` parameter. This PR fixes that.
In addition, I also improved the documentation. Both Rapidoc and Swagger UI require a `description` to display a webhook. Descriptions are not provided as tags but as Rust docs. This behaviour is not apparent from the Webhook example code.