### PR TITLE
Support deep linking in Swagger UI

### DIFF
--- a/poem-openapi/src/ui/swagger_ui/mod.rs
+++ b/poem-openapi/src/ui/swagger_ui/mod.rs
@@ -36,6 +36,7 @@ const SWAGGER_UI_TEMPLATE: &str = r#"
         spec: spec,
         filter: false,
         oauth2RedirectUrl: oauth2RedirectUrl,
+        deepLinking: true,
     })
 </script>
 


### PR DESCRIPTION
Adds support for [deep linking](https://swagger.io/docs/open-source-tools/swagger-ui/usage/deep-linking/) in Swagger UI, which makes it easier to keep API tabs/dropdowns open when refreshing the web page.

Would be very nice to have something like a `custom_swagger_ui(swagger_conf)` function added, so that deepLinking, filter and other properties can be configured manually. I'm happy to try my hand at implementing something like that if desirable :)