### PR TITLE
Fix grammatical errata, typos and repetitions

### DIFF
--- a/poem-openapi/src/validation/mod.rs
+++ b/poem-openapi/src/validation/mod.rs
@@ -26,9 +26,9 @@ pub use unique_items::UniqueItems;
 
 use crate::registry::MetaSchema;
 
-/// Represents a validator for validate the input value.
+/// Represents a validator to validate the input value.
 pub trait Validator<T>: Display {
-    /// Check the value is valid.
+    /// Checks if the value is valid.
     fn check(&self, value: &T) -> bool;
 }
 

--- a/poem/src/error.rs
+++ b/poem/src/error.rs
@@ -30,7 +30,7 @@ pub trait ResponseError {
     /// The status code of this error.
     fn status(&self) -> StatusCode;
 
-    /// Convert this error to a HTTP response.
+    /// Converts this error to an HTTP response.
     fn as_response(&self) -> Response
     where
         Self: StdError + Send + Sync + 'static,
@@ -103,7 +103,7 @@ impl AsResponse {
 /// }
 /// ```
 ///
-/// # Create you own error type
+/// # Create your own error type
 ///
 /// ```
 /// use poem::{Endpoint, Request, Result, error::ResponseError, handler, http::StatusCode};

--- a/poem/src/lib.rs
+++ b/poem/src/lib.rs
@@ -34,7 +34,7 @@
 //! # Endpoint
 //!
 //! The [`Endpoint`] trait represents a type that can handle HTTP requests, and
-//! it returns the `Result<T: IntoResponse, Error>` type.
+//! it returns a `Result<T: IntoResponse, Error>` type.
 //!
 //! The [`handler`] macro is used to convert a function into an endpoint.
 //!

--- a/poem/src/test/json.rs
+++ b/poem/src/test/json.rs
@@ -6,7 +6,7 @@ use serde_json::{Map, Value};
 pub struct TestJson(Value);
 
 impl TestJson {
-    /// Returns a reference the value.
+    /// Returns a reference to the value.
     #[inline]
     pub fn value(&self) -> TestJsonValue<'_> {
         TestJsonValue(&self.0)
@@ -133,17 +133,17 @@ impl<'a> TestJsonValue<'a> {
         self.array().iter().map(|value| value.string()).collect()
     }
 
-    /// Asserts that the value is an array and return `TestJsonArray`.
+    /// Asserts that the value is an array and returns `TestJsonArray`.
     pub fn array(&self) -> TestJsonArray<'a> {
         TestJsonArray(self.0.as_array().expect("array"))
     }
 
-    /// Asserts that the value is an object and return `TestJsonArray`.
+    /// Asserts that the value is an object and returns `TestJsonArray`.
     pub fn object(&self) -> TestJsonObject<'a> {
         TestJsonObject(self.0.as_object().expect("object"))
     }
 
-    /// Asserts that the value is an object array and return
+    /// Asserts that the value is an object array and returns
     /// `Vec<TestJsonObject>`.
     pub fn object_array(&self) -> Vec<TestJsonObject<'a>> {
         self.array().iter().map(|value| value.object()).collect()
@@ -198,7 +198,7 @@ impl<'a> TestJsonArray<'a> {
     }
 
     /// Returns the element at index `idx`, or `None` if the element does not
-    /// exists exists.
+    /// exist.
     pub fn get_opt(&self, idx: usize) -> Option<TestJsonValue<'a>> {
         self.0.get(idx).map(TestJsonValue)
     }
@@ -208,7 +208,7 @@ impl<'a> TestJsonArray<'a> {
         self.0.iter().map(TestJsonValue)
     }
 
-    /// Asserts the array length is equals to `len`.
+    /// Asserts the array length is equal to `len`.
     #[track_caller]
     pub fn assert_len(&self, len: usize) {
         assert_eq!(self.len(), len);
@@ -264,7 +264,7 @@ impl<'a> TestJsonObject<'a> {
     }
 
     /// Returns the element corresponding to the `name`, or `None` if the
-    /// element does not exists exists.
+    /// element does not exist.
     pub fn get_opt(&self, name: impl AsRef<str>) -> Option<TestJsonValue<'a>> {
         self.0.get(name.as_ref()).map(TestJsonValue)
     }
@@ -274,7 +274,7 @@ impl<'a> TestJsonObject<'a> {
         self.0.iter().map(|(k, v)| (k, TestJsonValue(v)))
     }
 
-    /// Asserts the object length is equals to `len`.
+    /// Asserts the object length is equal to `len`.
     #[track_caller]
     pub fn assert_len(&self, len: usize) {
         assert_eq!(self.len(), len);

--- a/poem/src/web/yaml.rs
+++ b/poem/src/web/yaml.rs
@@ -8,7 +8,7 @@ use crate::{
     web::RequestBody,
 };
 
-/// JSON extractor and response.
+/// YAML extractor and response.
 ///
 /// To extract the specified type of YAML from the body, `T` must implement
 /// [`serde::Deserialize`].


### PR DESCRIPTION
While looking at the documentation on how to create your own `Error` type, I had noticed some grammatical errata. This PR fixes all errata I could find while manually looking through the codebase.