### PR TITLE
Feat: Add cloudflare worker support using poem

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,8 @@ members = [
     "poem-grpc-build",
     "poem-grpc",
     "poem-mcpserver",
-    "poem-mcpserver-macros", "poem-worker",
+    "poem-mcpserver-macros",
+    "poem-worker",
 ]
 
 [workspace.package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
     "poem-grpc-build",
     "poem-grpc",
     "poem-mcpserver",
-    "poem-mcpserver-macros",
+    "poem-mcpserver-macros", "poem-worker",
 ]
 
 [workspace.package]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = ["poem/*", "openapi/*", "grpc/*", "mcpserver/*"]
+exclude = ["poem/worker-hello-world"]
 
 [workspace.package]
 version = "0.1.0"
@@ -14,6 +15,7 @@ poem-openapi = { path = "../poem-openapi", features = ["swagger-ui"] }
 poem-lambda = { path = "../poem-lambda" }
 poem-grpc-build = { path = "../poem-grpc-build" }
 poem-mcpserver = { path = "../poem-mcpserver" }
+poem-worker = { path = "../poem-worker" }
 
 tokio = "1.17.0"
 tracing-subscriber = { version = "0.3.9", features = ["env-filter"] }

--- a/examples/poem/worker-hello-world/.gitignore
+++ b/examples/poem/worker-hello-world/.gitignore
@@ -1,0 +1,4 @@
+target
+node_modules
+.wrangler
+build

--- a/examples/poem/worker-hello-world/Cargo.toml
+++ b/examples/poem/worker-hello-world/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "examples-worker-hello-world"
+version = "0.1.0"
+edition = "2021"
+
+[workspace]
+
+[package.metadata.release]
+release = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+worker = { version = "0.6.0" }
+poem = { path = "../../../poem", default-features = false }
+poem-worker = { path = "../../../poem-worker" }

--- a/examples/poem/worker-hello-world/README.md
+++ b/examples/poem/worker-hello-world/README.md
@@ -1,0 +1,6 @@
+# Poem with Cloudflare worker
+
+## Prequirement
+
+- [worker-build](https://github.com/cloudflare/workers-rs/tree/main/worker-build)
+- [wranger](https://developers.cloudflare.com/workers/wrangler/install-and-update/)

--- a/examples/poem/worker-hello-world/src/lib.rs
+++ b/examples/poem/worker-hello-world/src/lib.rs
@@ -1,9 +1,9 @@
 use poem::{get, handler, web::Path, Route};
-use poem_worker::Server;
+use poem_worker::{Cloudflareroperties, Server};
 use worker::event;
 
 #[handler]
-fn hello(Path(name): Path<String>) -> String {
+fn hello(Path(name): Path<String>, _cf: Cloudflareroperties) -> String {
     format!("hello: {}", name)
 }
 

--- a/examples/poem/worker-hello-world/src/lib.rs
+++ b/examples/poem/worker-hello-world/src/lib.rs
@@ -1,0 +1,15 @@
+use poem::{get, handler, web::Path, Route};
+use poem_worker::Server;
+use worker::event;
+
+#[handler]
+fn hello(Path(name): Path<String>) -> String {
+    format!("hello: {}", name)
+}
+
+#[event(start)]
+fn start() {
+    let app = Route::new().at("/hello/:name", get(hello));
+
+    Server::new().run(app);
+}

--- a/examples/poem/worker-hello-world/wrangler.toml
+++ b/examples/poem/worker-hello-world/wrangler.toml
@@ -1,0 +1,6 @@
+name = "worker-hello-world"
+main = "build/worker/shim.mjs"
+compatibility_date = "2025-07-20"
+
+[build]
+command = "worker-build --release"

--- a/poem-worker/Cargo.toml
+++ b/poem-worker/Cargo.toml
@@ -16,7 +16,7 @@ bytes = { workspace = true }
 http = { workspace = true }
 http-body = "1.0.1"
 http-body-util = "0.1.0"
-async-trait = "0.1"
+async-trait = "0.1.88"
 
 poem = { workspace = true, default-features = true }
 

--- a/poem-worker/Cargo.toml
+++ b/poem-worker/Cargo.toml
@@ -21,3 +21,7 @@ async-trait = "0.1.88"
 poem = { workspace = true, default-features = false }
 
 tokio = { workspace = true }
+
+[features]
+queue = ["worker/queue"]
+d1 = ["worker/d1"]

--- a/poem-worker/Cargo.toml
+++ b/poem-worker/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "poem-worker"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+documentation.workspace = true
+homepage.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+serde = { workspace = true }
+worker = { version = "0.6.0", features = ["http"] }
+bytes = { workspace = true }
+http = { workspace = true }
+http-body = "1.0.1"
+http-body-util = "0.1.0"
+async-trait = "0.1"
+
+poem = { workspace = true, default-features = true }
+
+tokio = { workspace = true, features = ["io-util", "rt", "sync", "net"] }

--- a/poem-worker/Cargo.toml
+++ b/poem-worker/Cargo.toml
@@ -20,4 +20,4 @@ async-trait = "0.1.88"
 
 poem = { workspace = true, default-features = true }
 
-tokio = { workspace = true, features = ["io-util", "rt", "sync", "net"] }
+tokio = { workspace = true }

--- a/poem-worker/Cargo.toml
+++ b/poem-worker/Cargo.toml
@@ -18,6 +18,6 @@ http-body = "1.0.1"
 http-body-util = "0.1.0"
 async-trait = "0.1.88"
 
-poem = { workspace = true, default-features = true }
+poem = { workspace = true, default-features = false }
 
 tokio = { workspace = true }

--- a/poem-worker/src/body.rs
+++ b/poem-worker/src/body.rs
@@ -1,0 +1,54 @@
+use std::{
+    io,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use http_body::{Body, Frame, SizeHint};
+
+pub struct WorkerBody(pub(crate) worker::Body);
+
+impl Body for WorkerBody {
+    type Data = bytes::Bytes;
+    type Error = io::Error;
+
+    #[inline]
+    fn poll_frame(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        let body = self.get_mut();
+
+        let inner = Pin::new(&mut body.0);
+
+        let res = inner.poll_frame(cx);
+
+        match res {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Ready(Some(Ok(r))) => Poll::Ready(Some(Ok(r))),
+            Poll::Ready(Some(Err(e))) => match e {
+                worker::Error::Io(e) => {
+                    Poll::Ready(Some(Err(io::Error::new(io::ErrorKind::Other, e))))
+                }
+                _ => Poll::Ready(Some(Err(io::Error::other(e)))),
+            },
+        }
+    }
+
+    fn size_hint(&self) -> SizeHint {
+        self.0.size_hint()
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.0.is_end_stream()
+    }
+}
+
+pub fn build_worker_body(body: poem::Body) -> Result<worker::Body, worker::Error> {
+    let stream = body.into_bytes_stream();
+
+    let res = worker::Body::from_stream(stream);
+
+    res
+}

--- a/poem-worker/src/cloudflare.rs
+++ b/poem-worker/src/cloudflare.rs
@@ -1,0 +1,93 @@
+use http::StatusCode;
+use poem::{FromRequest, Request, RequestBody};
+use serde::de::DeserializeOwned;
+use worker::{Cf, TlsClientAuth};
+
+pub struct Cloudflareroperties(Cf);
+
+impl Cloudflareroperties {
+    pub fn colo(&self) -> String {
+        self.0.colo()
+    }
+
+    pub fn asn(&self) -> u32 {
+        self.0.asn()
+    }
+
+    pub fn as_organization(&self) -> String {
+        self.0.as_organization()
+    }
+
+    pub fn country(&self) -> Option<String> {
+        self.0.country()
+    }
+
+    pub fn http_protocol(&self) -> String {
+        self.0.http_protocol()
+    }
+
+    pub fn tls_cipher(&self) -> String {
+        self.0.tls_cipher()
+    }
+
+    pub fn tls_client_auth(&self) -> Option<TlsClientAuth> {
+        self.0.tls_client_auth()
+    }
+
+    pub fn tls_version(&self) -> String {
+        self.0.tls_version()
+    }
+
+    pub fn city(&self) -> Option<String> {
+        self.0.city()
+    }
+
+    pub fn continent(&self) -> Option<String> {
+        self.0.continent()
+    }
+
+    pub fn coordinates(&self) -> Option<(f32, f32)> {
+        self.0.coordinates()
+    }
+
+    pub fn postal_code(&self) -> Option<String> {
+        self.0.postal_code()
+    }
+
+    pub fn metro_code(&self) -> Option<String> {
+        self.0.metro_code()
+    }
+
+    pub fn region(&self) -> Option<String> {
+        self.0.region()
+    }
+
+    pub fn region_code(&self) -> Option<String> {
+        self.0.region_code()
+    }
+
+    pub fn timezone_name(&self) -> String {
+        self.0.timezone_name()
+    }
+
+    pub fn is_eu_country(&self) -> bool {
+        self.0.is_eu_country()
+    }
+
+    pub fn host_metadata<T: DeserializeOwned>(&self) -> Result<Option<T>, worker::Error> {
+        self.0.host_metadata::<T>()
+    }
+}
+
+impl<'a> FromRequest<'a> for Cloudflareroperties {
+    async fn from_request(req: &'a Request, _body: &mut RequestBody) -> Result<Self, poem::Error> {
+        let cf = req.data::<Cf>().ok_or_else(|| {
+            poem::Error::from_string(
+                "failed to get incoming cloudflare properties",
+                StatusCode::BAD_REQUEST,
+            )
+        })?;
+
+        Ok(Cloudflareroperties(cf.clone()))
+    }
+}

--- a/poem-worker/src/context.rs
+++ b/poem-worker/src/context.rs
@@ -1,0 +1,34 @@
+use std::sync::Arc;
+
+use http::StatusCode;
+use poem::{FromRequest, Request, RequestBody};
+
+#[derive(Clone)]
+pub struct Context(Arc<worker::Context>);
+
+impl Context {
+    pub fn new(ctx: worker::Context) -> Self {
+        Self(Arc::new(ctx))
+    }
+
+    pub fn wait_until<F>(&self, future: F)
+    where
+        F: Future<Output = ()> + 'static,
+    {
+        self.0.wait_until(future);
+    }
+
+    pub fn pass_through_on_exception(&self) {
+        self.0.pass_through_on_exception();
+    }
+}
+
+impl<'a> FromRequest<'a> for Context {
+    async fn from_request(req: &'a Request, _body: &mut RequestBody) -> poem::Result<Self> {
+        let ctx = req.data::<Context>().ok_or_else(|| {
+            poem::Error::from_string("failed to get incoming context", StatusCode::BAD_REQUEST)
+        })?;
+
+        Ok(ctx.clone())
+    }
+}

--- a/poem-worker/src/env.rs
+++ b/poem-worker/src/env.rs
@@ -1,0 +1,90 @@
+use std::sync::Arc;
+
+use http::StatusCode;
+use poem::{FromRequest, Request, RequestBody};
+use serde::de::DeserializeOwned;
+use worker::{
+    Ai, AnalyticsEngineDataset, Bucket, DynamicDispatcher, EnvBinding, Fetcher, Hyperdrive,
+    ObjectNamespace, Secret, Var, kv::KvStore,
+};
+
+#[derive(Clone)]
+pub struct Env(pub(crate) Arc<worker::Env>);
+
+impl Env {
+    pub fn new(env: worker::Env) -> Self {
+        Self(Arc::new(env))
+    }
+
+    pub fn get_binding<T: EnvBinding>(&self, name: &str) -> worker::Result<T> {
+        self.0.get_binding(name)
+    }
+
+    pub fn ai(&self, binding: &str) -> worker::Result<Ai> {
+        self.0.ai(binding)
+    }
+
+    pub fn analytics_engine(&self, binding: &str) -> worker::Result<AnalyticsEngineDataset> {
+        self.0.analytics_engine(binding)
+    }
+
+    pub fn secret(&self, binding: &str) -> worker::Result<Secret> {
+        self.0.secret(binding)
+    }
+
+    pub fn var(&self, binding: &str) -> worker::Result<Var> {
+        self.0.var(binding)
+    }
+
+    pub fn object_var<T: DeserializeOwned>(&self, binding: &str) -> worker::Result<T> {
+        self.0.object_var(binding)
+    }
+
+    pub fn kv(&self, binding: &str) -> worker::Result<KvStore> {
+        self.0.kv(binding)
+    }
+
+    pub fn durable_object(&self, binding: &str) -> worker::Result<ObjectNamespace> {
+        self.0.durable_object(binding)
+    }
+
+    pub fn dynamic_dispatcher(&self, binding: &str) -> worker::Result<DynamicDispatcher> {
+        self.0.dynamic_dispatcher(binding)
+    }
+
+    pub fn service(&self, binding: &str) -> worker::Result<Fetcher> {
+        self.0.service(binding)
+    }
+
+    #[cfg(feature = "queue")]
+    pub fn queue(&self, binding: &str) -> worker::Result<worker::Queue> {
+        self.0.queue(binding)
+    }
+
+    pub fn bucket(&self, binding: &str) -> worker::Result<Bucket> {
+        self.0.bucket(binding)
+    }
+
+    #[cfg(feature = "d1")]
+    pub fn d1(&self, binding: &str) -> worker::Result<worker::D1Database> {
+        self.0.d1(binding)
+    }
+
+    pub fn assets(&self, binding: &str) -> worker::Result<Fetcher> {
+        self.0.assets(binding)
+    }
+
+    pub fn hyperdrive(&self, binding: &str) -> worker::Result<Hyperdrive> {
+        self.0.hyperdrive(binding)
+    }
+}
+
+impl<'a> FromRequest<'a> for Env {
+    async fn from_request(req: &'a Request, _body: &mut RequestBody) -> poem::Result<Self> {
+        let env = req.data::<Env>().ok_or_else(|| {
+            poem::Error::from_string("failed to get incoming env", StatusCode::BAD_REQUEST)
+        })?;
+
+        Ok(env.clone())
+    }
+}

--- a/poem-worker/src/lib.rs
+++ b/poem-worker/src/lib.rs
@@ -6,5 +6,4 @@ pub use cloudflare::*;
 
 mod server;
 pub use server::*;
-
-pub use worker::*;
+pub use worker;

--- a/poem-worker/src/lib.rs
+++ b/poem-worker/src/lib.rs
@@ -4,5 +4,11 @@ pub(crate) mod req;
 mod cloudflare;
 pub use cloudflare::*;
 
+mod env;
+pub use env::*;
+
+mod context;
+pub use context::*;
+
 mod server;
 pub use server::*;

--- a/poem-worker/src/lib.rs
+++ b/poem-worker/src/lib.rs
@@ -6,4 +6,3 @@ pub use cloudflare::*;
 
 mod server;
 pub use server::*;
-pub use worker;

--- a/poem-worker/src/lib.rs
+++ b/poem-worker/src/lib.rs
@@ -1,0 +1,10 @@
+pub(crate) mod body;
+pub(crate) mod req;
+
+mod cloudflare;
+pub use cloudflare::*;
+
+mod server;
+pub use server::*;
+
+pub use worker::*;

--- a/poem-worker/src/req.rs
+++ b/poem-worker/src/req.rs
@@ -1,0 +1,61 @@
+use std::net::{IpAddr, SocketAddr};
+
+use http::uri::Scheme;
+use http_body_util::combinators::BoxBody;
+use poem::{
+    web::{LocalAddr, RemoteAddr},
+    Request,
+};
+use worker::{HttpRequest, Result};
+
+pub fn build_poem_req(req: HttpRequest) -> Result<poem::Request> {
+    let headers = req.headers();
+
+    let local_addr = if let Some(client_ip) = headers.get("cf-connecting-ip") {
+        let client_ip = client_ip
+            .to_str()
+            .map_err(|e| worker::Error::RustError(format!("{}", e)))?;
+
+        let ip_addr = client_ip
+            .parse::<IpAddr>()
+            .map_err(|e| worker::Error::RustError(format!("{}", e)))?;
+
+        let addr = SocketAddr::new(ip_addr, 0);
+
+        LocalAddr(poem::Addr::SocketAddr(addr))
+    } else {
+        LocalAddr::default()
+    };
+
+    let remote_addr = RemoteAddr(poem::Addr::Custom("worker", "".into()));
+    let scheme = Scheme::HTTPS;
+
+    let (parts, body) = req.into_parts();
+    let body = crate::body::WorkerBody(body);
+    let boxed_body = BoxBody::new(body);
+
+    let body = poem::Body::from(boxed_body);
+    let request_parts = poem::RequestParts::from((parts, local_addr, remote_addr, scheme));
+
+    Ok(Request::from_parts(request_parts, body))
+}
+
+pub fn build_worker_resp(resp: poem::Response) -> Result<worker::HttpResponse> {
+    let (parts, body) = resp.into_parts();
+    let body = crate::body::build_worker_body(body)?;
+
+    let mut builder = http::Response::builder()
+        .status(parts.status)
+        .version(parts.version)
+        .extension(parts.extensions);
+
+    for (key, value) in parts.headers {
+        if let Some(key) = key {
+            builder = builder.header(key, value);
+        }
+    }
+
+    let resp = builder.body(body)?;
+
+    Ok(resp)
+}

--- a/poem-worker/src/server.rs
+++ b/poem-worker/src/server.rs
@@ -3,7 +3,7 @@ use poem::endpoint::Endpoint;
 use tokio::sync::OnceCell;
 
 #[worker::event(fetch)]
-async fn fetch(
+pub async fn fetch(
     request: worker::Request,
     _env: worker::Env,
     _ctx: worker::Context,

--- a/poem-worker/src/server.rs
+++ b/poem-worker/src/server.rs
@@ -1,0 +1,59 @@
+use async_trait::async_trait;
+use poem::endpoint::Endpoint;
+use tokio::sync::OnceCell;
+
+#[worker::event(fetch)]
+async fn fetch(
+    request: worker::Request,
+    _env: worker::Env,
+    _ctx: worker::Context,
+) -> Result<worker::Response, worker::Error> {
+    let cf = request.cf().cloned();
+
+    let http_req = worker::HttpRequest::try_from(request)?;
+    let mut poem_req = crate::req::build_poem_req(http_req)?;
+
+    if let Some(cf) = cf {
+        poem_req.set_data(cf);
+    }
+
+    // TODO: handle error
+    let app = SERVER_INSTANCE.get().unwrap();
+
+    let resp = app.get_poem_response(poem_req).await;
+    let worker_resp = crate::req::build_worker_resp(resp)?;
+    let resp = worker::Response::try_from(worker_resp)?;
+
+    Ok(resp)
+}
+
+#[async_trait]
+trait GetResponseInner: Send + Sync + 'static {
+    async fn get_poem_response(&self, req: poem::Request) -> poem::Response;
+}
+
+#[async_trait]
+impl<E: Endpoint + Send + Sync + 'static> GetResponseInner for E {
+    async fn get_poem_response(&self, req: poem::Request) -> poem::Response {
+        self.get_response(req).await
+    }
+}
+
+pub struct Server {}
+
+type BoxedGetResponseInner = Box<dyn GetResponseInner>;
+
+static SERVER_INSTANCE: OnceCell<BoxedGetResponseInner> = OnceCell::const_new();
+
+impl Server {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    pub fn run(&self, app: impl Endpoint + 'static) {
+        SERVER_INSTANCE
+            .set(Box::new(app))
+            .map_err(|_| format!("Server instance can only be set once"))
+            .unwrap();
+    }
+}

--- a/poem-worker/src/server.rs
+++ b/poem-worker/src/server.rs
@@ -17,6 +17,8 @@ pub async fn fetch(
         poem_req.set_data(cf);
     }
 
+    poem_req.set_data(crate::Env::new(_env));
+
     // TODO: handle error
     let app = SERVER_INSTANCE.get().unwrap();
 

--- a/poem/Cargo.toml
+++ b/poem/Cargo.toml
@@ -21,7 +21,13 @@ categories = [
 [features]
 default = ["server"]
 
-server = ["tokio/rt", "tokio/net", "hyper/server"]
+server = [
+    "tokio/rt",
+    "tokio/net",
+    "hyper/server",
+    "hyper-util/server-auto",
+    "hyper-util/tokio",
+]
 websocket = ["tokio/rt", "tokio-tungstenite", "base64"]
 multipart = ["multer"]
 rustls = ["server", "tokio-rustls", "rustls-pemfile"]
@@ -76,9 +82,10 @@ bytes.workspace = true
 futures-util = { workspace = true, features = ["sink"] }
 http.workspace = true
 hyper = { version = "1.0.0", features = ["http1", "http2"] }
-hyper-util = { version = "0.1.6", features = ["server-auto", "tokio"] }
+hyper-util = { version = "0.1.6" }
+hyper-tokio-io = "0.1"
 http-body-util = "0.1.0"
-tokio = { workspace = true, features = ["sync", "time", "macros", "net"] }
+tokio = { workspace = true, features = ["sync", "time", "macros"] }
 tokio-util = { workspace = true, features = ["io"] }
 serde.workspace = true
 sonic-rs = { workspace = true, optional = true }

--- a/poem/src/request.rs
+++ b/poem/src/request.rs
@@ -489,7 +489,7 @@ impl AsyncRead for Upgraded {
         cx: &mut Context<'_>,
         buf: &mut ReadBuf<'_>,
     ) -> Poll<std::io::Result<()>> {
-        Pin::new(&mut hyper_util::rt::TokioIo::new(self.project().stream)).poll_read(cx, buf)
+        Pin::new(&mut hyper_tokio_io::TokioIo::new(self.project().stream)).poll_read(cx, buf)
     }
 }
 

--- a/poem/src/server.rs
+++ b/poem/src/server.rs
@@ -457,7 +457,7 @@ where
         .max_header_list_size(http2_max_header_list_size);
 
     let conn =
-        builder.serve_connection_with_upgrades(hyper_util::rt::TokioIo::new(socket), service);
+        builder.serve_connection_with_upgrades(hyper_tokio_io::TokioIo::new(socket), service);
     futures_util::pin_mut!(conn);
 
     tokio::select! {

--- a/poem/src/server.rs
+++ b/poem/src/server.rs
@@ -457,7 +457,7 @@ where
         .max_header_list_size(http2_max_header_list_size);
 
     let conn =
-        builder.serve_connection_with_upgrades(hyper_tokio_io::TokioIo::new(socket), service);
+        builder.serve_connection_with_upgrades(hyper_util::rt::TokioIo::new(socket), service);
     futures_util::pin_mut!(conn);
 
     tokio::select! {


### PR DESCRIPTION
By making minor modifications to Poem (modification of 1 function and 1 dependency), Poem can be compiled to wasm and some Cloudflare related APIs are provided. Now we can use poem to write cloudflare worker.

Note: I separated `TokioIo` from `hyper-util` to avoid using this type to import `tokio/net`. I also submitted a PR to `hyper-util`, but I don't know when it can be merged.