### PR TITLE
add note about rate limits for letsencrypt

### DIFF
--- a/poem/src/listener/acme/builder.rs
+++ b/poem/src/listener/acme/builder.rs
@@ -67,6 +67,12 @@ impl AutoCertBuilder {
     /// This is not a necessary option. If you do not configure the cache path,
     /// the obtained certificate will be stored in memory and will need to be
     /// obtained again when the server is restarted next time.
+    ///
+    /// Note that the default ACME service, Letsencrypt, only allows [five
+    /// certificates to be issued](https://letsencrypt.org/docs/rate-limits/#new-certificates-per-exact-set-of-identifiers)
+    /// for an exact set of domains every seven days. If cache path is omitted,
+    /// each application restart will count toward this limit, which can prevent
+    /// new certificate issuance from succeeding for 34 hours once reached.
     #[must_use]
     pub fn cache_path(self, path: impl Into<PathBuf>) -> Self {
         Self {


### PR DESCRIPTION
with the default AutoCert configuration (letsencrypt and no cache path), it only takes five app restarts to exhaust the production letsencrypt cert issuance limit. The next restart then has to be delayed **34 hours** to successfully receive a cert.

i think the existing doc comment for `cache_path` makes it seem relatively safe to omit. i was aware of letsencrypt's pretty strict rate limits, but was expecting it to only be a couple hours if i reached it. it's not super fun to wait 1.5 days.

this change balances the existing doc comment with a letsencrypt-specific note about this limit and long lockout.