### PR TITLE
fix(poem): use tokio feature "net"

### DIFF
--- a/poem/Cargo.toml
+++ b/poem/Cargo.toml
@@ -84,7 +84,7 @@ http.workspace = true
 hyper = { version = "1.0.0", features = ["http1", "http2"] }
 hyper-util = { version = "0.1.16", features = ["tokio"] }
 http-body-util = "0.1.0"
-tokio = { workspace = true, features = ["sync", "time", "macros"] }
+tokio = { workspace = true, features = ["sync", "time", "macros", "net"] }
 tokio-util = { workspace = true, features = ["io"] }
 serde.workspace = true
 sonic-rs = { workspace = true, optional = true }


### PR DESCRIPTION
On Unix target platforms, e.g. Linux, [`poem::Addr`] contains a variant `Unix(Arc<tokio::net::unix::SocketAddr>)`. The type `tokio::net::unix::SocketAddr` is only defined on Unix platforms and if the tokio feature `"net"` is enabled:
* [tokio: net/mod.rs:38](https://docs.rs/crate/tokio/1.47.1/source/src/net/mod.rs#38)
* [tokio: macros/cfg.rs:317](https://docs.rs/crate/tokio/1.47.1/source/src/macros/cfg.rs#317)

This PR makes Poem depend on tokio's feature `"net"`, so the `cfg` gate is fulfilled. Downstream users may -- [for some reason] or another -- not depend on tokio at all, which would have mitigated the error introduced in [PR #1075].

[`poem::Addr`]: <https://github.com/poem-web/poem/blob/f6e509b8c3f1a9417b5f3c3d6e2ec5ca9c99e6da/poem/src/addr.rs#L14>
[tokio: net/mod.rs:38]: <https://docs.rs/crate/tokio/1.47.1/source/src/net/mod.rs#38>
[tokio: macros/cfg.rs:317]: <https://docs.rs/crate/tokio/1.47.1/source/src/macros/cfg.rs#317>
[for some reason]: <https://github.com/askama-rs/askama_web/actions/runs/16666803605/job/47174694619#step:6:219>
[PR #1075]: <https://github.com/poem-web/poem/commit/9d5aa37374795793d4db24ac0ea84e3cd05068b4#diff-4885e58773e331e625bfa0de9cc693d2e30ee0e0f292062e206d95bda9228817L81>