### PR TITLE
fix(deps): add macros feature to time dependency

### DIFF
--- a/poem-openapi/Cargo.toml
+++ b/poem-openapi/Cargo.toml
@@ -66,6 +66,7 @@ chrono = { workspace = true, optional = true, default-features = false, features
 time = { workspace = true, optional = true, features = [
   "parsing",
   "formatting",
+  "macros",
 ] }
 uuid = { version = "1.1.0", optional = true }
 url = { version = "2.2.2", optional = true }


### PR DESCRIPTION
Resolves compilation error when time feature is enabled:
- Add "macros" feature to time dependency in Cargo.toml
- Fixes unresolved import `time::macros` error in poem-openapi

Fixes build failure when using poem-openapi with time feature enabled.