### PR TITLE
feat(openapi): add `Type`, `To*`, and `ParseFrom*` implementations for `unit` type

### DIFF
--- a/examples/openapi/uniform-response/src/main.rs
+++ b/examples/openapi/uniform-response/src/main.rs
@@ -85,6 +85,12 @@ impl Api {
         *self.resource.lock().await = Some(obj.0);
         MyResponse::Ok(Json(ResponseObject::ok(true)))
     }
+
+    #[oai(path = "/resource", method = "post")]
+    async fn post(&self, obj: Json<Resource>) -> MyResponse<()> {
+        *self.resource.lock().await = Some(obj.0);
+        MyResponse::Ok(Json(ResponseObject::ok(())))
+    }
 }
 
 #[tokio::main]

--- a/poem-openapi/src/types/external/mod.rs
+++ b/poem-openapi/src/types/external/mod.rs
@@ -31,6 +31,7 @@ mod sqlx;
 mod string;
 #[cfg(feature = "time")]
 mod time;
+mod unit;
 mod uri;
 #[cfg(feature = "url")]
 mod url;

--- a/poem-openapi/src/types/external/unit.rs
+++ b/poem-openapi/src/types/external/unit.rs
@@ -1,0 +1,68 @@
+use std::borrow::Cow;
+
+use poem::{http::HeaderValue, web::Field};
+use serde_json::Value;
+
+use crate::{
+    registry::{MetaSchema, MetaSchemaRef},
+    types::{
+        ParseFromJSON, ParseFromMultipartField, ParseFromParameter, ParseResult, ToHeader, ToJSON,
+        Type,
+    },
+};
+
+impl Type for () {
+    const IS_REQUIRED: bool = false;
+
+    type RawValueType = Self;
+
+    type RawElementValueType = Self;
+
+    fn name() -> Cow<'static, str> {
+        "unit".into()
+    }
+
+    fn schema_ref() -> MetaSchemaRef {
+        MetaSchemaRef::Inline(Box::new(MetaSchema::new("unit")))
+    }
+
+    fn as_raw_value(&self) -> Option<&Self::RawValueType> {
+        Some(self)
+    }
+
+    fn raw_element_iter<'a>(
+        &'a self,
+    ) -> Box<dyn Iterator<Item = &'a Self::RawElementValueType> + 'a> {
+        Box::new(self.as_raw_value().into_iter())
+    }
+}
+
+impl ParseFromJSON for () {
+    fn parse_from_json(_: Option<Value>) -> ParseResult<Self> {
+        Ok(())
+    }
+}
+
+impl ParseFromParameter for () {
+    fn parse_from_parameter(_: &str) -> ParseResult<Self> {
+        Ok(())
+    }
+}
+
+impl ParseFromMultipartField for () {
+    async fn parse_from_multipart(_: Option<Field>) -> ParseResult<Self> {
+        Ok(())
+    }
+}
+
+impl ToJSON for () {
+    fn to_json(&self) -> Option<Value> {
+        Some(Value::Null)
+    }
+}
+
+impl ToHeader for () {
+    fn to_header(&self) -> Option<HeaderValue> {
+        None
+    }
+}

--- a/poem-openapi/src/types/external/unit.rs
+++ b/poem-openapi/src/types/external/unit.rs
@@ -66,3 +66,57 @@ impl ToHeader for () {
         None
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn type_name() {
+        assert_eq!(<()>::name(), "unit");
+    }
+
+    #[test]
+    fn parse_from_json_none() {
+        assert_eq!(
+            <()>::parse_from_json(None).expect("failed to parse 'None'"),
+            ()
+        );
+    }
+
+    #[test]
+    fn parse_from_json_value_null() {
+        assert_eq!(
+            <()>::parse_from_json(Some(Value::Null)).expect("failed to parse 'Value::Null'"),
+            ()
+        );
+    }
+
+    #[test]
+    fn parse_from_parameter() {
+        assert_eq!(
+            <()>::parse_from_parameter("").expect("failed to parse ''"),
+            ()
+        );
+    }
+
+    #[tokio::test]
+    async fn parse_from_multipart_none() {
+        assert_eq!(
+            <()>::parse_from_multipart(None)
+                .await
+                .expect("failed to parse 'None'"),
+            ()
+        );
+    }
+
+    #[test]
+    fn to_json() {
+        assert_eq!(().to_json(), Some(Value::Null));
+    }
+
+    #[test]
+    fn to_header() {
+        assert_eq!(().to_header(), None);
+    }
+}


### PR DESCRIPTION
Motivation
---
Implementing patterns such as uniform response, as demonstrated in `examples/openapi/uniform-response`, where a response type generic over `T` is used to return `T` in a data field is awkward when unit type is desired. For cases where there is no meaningful `T`, without being able to use `()` as `T`, one is forced to use work arounds such as `#[derive(Object)] struct Unit;` or `types::Any<()>`. These changes will allow using `()` directly for those use cases. The deserialization and serialization behavior matches the behavior of serde_json's behavior for unit types.

Modifications
---
- Add `Type`, `ParseFromJSON`, `ParseFromParameter`, `ParseFromMultipartField`, `ToJSON`, and `ToHeader` trait implementation for unit type.
- Update OpenAPI uniform response example to use unit type in MyResponse to demonstrate use case.