### PR TITLE
fix(poem-openapi): correctly merge schema refs with parent object properties

### DIFF
--- a/poem-openapi/src/registry/mod.rs
+++ b/poem-openapi/src/registry/mod.rs
@@ -338,10 +338,7 @@ impl MetaSchemaRef {
                     MetaSchemaRef::Reference(name)
                 } else {
                     MetaSchemaRef::Inline(Box::new(MetaSchema {
-                        all_of: vec![
-                            MetaSchemaRef::Reference(name),
-                            MetaSchemaRef::Inline(Box::new(other.clone())),
-                        ],
+                        all_of: vec![MetaSchemaRef::Reference(name)],
                         ..other
                     }))
                 }

--- a/poem-openapi/tests/multipart.rs
+++ b/poem-openapi/tests/multipart.rs
@@ -496,32 +496,26 @@ fn inline_field() {
 
     let meta_inner_obj = schema.properties[0].1.unwrap_inline();
     assert_eq!(
-        meta_inner_obj.all_of[0],
-        MetaSchemaRef::Reference("InlineObj".to_string())
-    );
-    assert_eq!(
-        meta_inner_obj.all_of[1],
-        MetaSchemaRef::Inline(Box::new(MetaSchema {
+        meta_inner_obj,
+        &MetaSchema {
             description: Some("Inner Obj"),
             default: Some(serde_json::json!({
                 "v": 100,
             })),
+            all_of: vec![MetaSchemaRef::Reference("InlineObj".to_string())],
             ..MetaSchema::ANY
-        }))
+        }
     );
 
     let meta_inner_enum = schema.properties[1].1.unwrap_inline();
     assert_eq!(
-        meta_inner_enum.all_of[0],
-        MetaSchemaRef::Reference("InlineEnum".to_string())
-    );
-    assert_eq!(
-        meta_inner_enum.all_of[1],
-        MetaSchemaRef::Inline(Box::new(MetaSchema {
+        meta_inner_enum,
+        &MetaSchema {
             description: Some("Inner Enum"),
             default: Some(serde_json::json!("B")),
+            all_of: vec![MetaSchemaRef::Reference("InlineEnum".to_string())],
             ..MetaSchema::ANY
-        }))
+        }
     );
 }
 

--- a/poem-openapi/tests/object.rs
+++ b/poem-openapi/tests/object.rs
@@ -495,32 +495,26 @@ fn inline_fields() {
 
     let meta_inner_obj = meta.properties[0].1.unwrap_inline();
     assert_eq!(
-        meta_inner_obj.all_of[0],
-        MetaSchemaRef::Reference("InlineObj".to_string())
-    );
-    assert_eq!(
-        meta_inner_obj.all_of[1],
-        MetaSchemaRef::Inline(Box::new(MetaSchema {
+        meta_inner_obj,
+        &MetaSchema {
             description: Some("Inner Obj"),
             default: Some(serde_json::json!({
                 "v": 100,
             })),
+            all_of: vec![MetaSchemaRef::Reference("InlineObj".to_string())],
             ..MetaSchema::ANY
-        }))
+        }
     );
 
     let meta_inner_enum = meta.properties[1].1.unwrap_inline();
     assert_eq!(
-        meta_inner_enum.all_of[0],
-        MetaSchemaRef::Reference("InlineEnum".to_string())
-    );
-    assert_eq!(
-        meta_inner_enum.all_of[1],
-        MetaSchemaRef::Inline(Box::new(MetaSchema {
+        meta_inner_enum,
+        &MetaSchema {
             description: Some("Inner Enum"),
             default: Some(serde_json::json!("B")),
+            all_of: vec![MetaSchemaRef::Reference("InlineEnum".to_string())],
             ..MetaSchema::ANY
-        }))
+        }
     );
 }
 


### PR DESCRIPTION
This PR addresses an issue introduced in commit https://github.com/poem-web/poem/commit/b16f72e797caedd02661a9f46c043976069ed938, where the merge logic in `MetaSchema::merge` was modified. The diff is as follows:

```diff
#[must_use]
pub fn merge(self, other: MetaSchema) -> Self {
    match self {
        MetaSchemaRef::Inline(schema) => MetaSchemaRef::Inline(Box::new(schema.merge(other))),
        MetaSchemaRef::Reference(name) => {
            let other = MetaSchema::ANY.merge(other);
            if other.is_empty() {
                MetaSchemaRef::Reference(name)
            } else {
                MetaSchemaRef::Inline(Box::new(MetaSchema {
                    all_of: vec![
                        MetaSchemaRef::Reference(name),
-                       MetaSchemaRef::Inline(Box::new(other)),
+                       MetaSchemaRef::Inline(Box::new(other.clone())),
                    ],
-                   ..MetaSchema::ANY
+                   ..other
                }))
            }
        }
    }
}
```

It appears that the second entry in the `all_of` array should have been removed, as the merging of properties from the parent schema now occurs directly.

This change has led to a bug in schema generation. For example, the following YAML:
```yaml
FieldPredictionBox:
  type: object
  properties:
    boundingPoly:
      description: The bounding polygon of the word on the page, as a list of vertices.
      allOf:
      - $ref: '#/components/schemas/BoundingPoly'
      - description: The bounding polygon of the word on the page, as a list of vertices.
```
should instead be:
```yaml
FieldPredictionBox:
  type: object
  properties:
    boundingPoly:
      description: The bounding polygon of the word on the page, as a list of vertices.
      allOf:
      - $ref: '#/components/schemas/BoundingPoly'
```