### PR TITLE
feat(openapi): add `Type`, `To*`, and `ParseFrom*` implementations for `ulid::Ulid` type

### DIFF
--- a/poem-openapi/Cargo.toml
+++ b/poem-openapi/Cargo.toml
@@ -27,6 +27,7 @@ websocket = ["poem/websocket"]
 geo = ["dep:geo-types", "dep:geojson"]
 sonic-rs = ["poem/sonic-rs"]
 cookie = ["poem/cookie"]
+ulid = ["dep:ulid"]
 
 [dependencies]
 poem-openapi-derive.workspace = true
@@ -83,6 +84,7 @@ sqlx = { version = "0.8.3", features = [
   "sqlite",
   "mysql",
 ], optional = true }
+ulid = { version = "1.2.1", optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/poem-openapi/README.md
+++ b/poem-openapi/README.md
@@ -63,6 +63,7 @@ To avoid compiling unused dependencies, Poem gates certain features, some of whi
 | stoplight-elements | Add Stoplight Elements UI support                                                                                                                                  |
 | email              | Support for email address string                                                                                                                                   |
 | hostname           | Support for hostname string                                                                                                                                        |
+| ulid               | Integrate with the [`ulid` crate](https://crates.io/crates/ulid)                                                                                                   |
 | uuid               | Integrate with the [`uuid` crate](https://crates.io/crates/uuid)                                                                                                   |
 | url                | Integrate with the [`url` crate](https://crates.io/crates/url)                                                                                                     |
 | geo                | Integrate with the [`geo-types` crate](https://crates.io/crates/geo-types)                                                                                         |

--- a/poem-openapi/src/lib.rs
+++ b/poem-openapi/src/lib.rs
@@ -106,6 +106,7 @@
 //! | email              | Support for email address string                                                       |
 //! | hostname           | Support for hostname string                                                            |
 //! | humantime          | Integrate with the [`humantime` crate](https://crates.io/crates/humantime)             |
+//! | ulid               | Integrate with the [`ulid` crate](https://crates.io/crates/ulid)                       |
 //! | uuid               | Integrate with the [`uuid` crate](https://crates.io/crates/uuid)                       |
 //! | url                | Integrate with the [`url` crate](https://crates.io/crates/url)                         |
 //! | geo                | Integrate with the [`geo-types` crate](https://crates.io/crates/geo-types)             |

--- a/poem-openapi/src/types/external/mod.rs
+++ b/poem-openapi/src/types/external/mod.rs
@@ -31,6 +31,8 @@ mod sqlx;
 mod string;
 #[cfg(feature = "time")]
 mod time;
+#[cfg(feature = "ulid")]
+mod ulid;
 mod unit;
 mod uri;
 #[cfg(feature = "url")]

--- a/poem-openapi/src/types/external/ulid.rs
+++ b/poem-openapi/src/types/external/ulid.rs
@@ -1,0 +1,77 @@
+use std::borrow::Cow;
+
+use poem::{http::HeaderValue, web::Field};
+use serde_json::Value;
+use ulid::Ulid;
+
+use crate::{
+    registry::{MetaSchema, MetaSchemaRef},
+    types::{
+        ParseError, ParseFromJSON, ParseFromMultipartField, ParseFromParameter, ParseResult,
+        ToHeader, ToJSON, Type,
+    },
+};
+
+impl Type for Ulid {
+    const IS_REQUIRED: bool = true;
+
+    type RawValueType = Self;
+
+    type RawElementValueType = Self;
+
+    fn name() -> Cow<'static, str> {
+        "string_ulid".into()
+    }
+
+    fn schema_ref() -> MetaSchemaRef {
+        MetaSchemaRef::Inline(Box::new(MetaSchema::new_with_format("string", "ulid")))
+    }
+
+    fn as_raw_value(&self) -> Option<&Self::RawValueType> {
+        Some(self)
+    }
+
+    fn raw_element_iter<'a>(
+        &'a self,
+    ) -> Box<dyn Iterator<Item = &'a Self::RawElementValueType> + 'a> {
+        Box::new(self.as_raw_value().into_iter())
+    }
+}
+
+impl ParseFromJSON for Ulid {
+    fn parse_from_json(value: Option<Value>) -> ParseResult<Self> {
+        let value = value.unwrap_or_default();
+        if let Value::String(value) = value {
+            Ok(value.parse()?)
+        } else {
+            Err(ParseError::expected_type(value))
+        }
+    }
+}
+
+impl ParseFromParameter for Ulid {
+    fn parse_from_parameter(value: &str) -> ParseResult<Self> {
+        value.parse().map_err(ParseError::custom)
+    }
+}
+
+impl ParseFromMultipartField for Ulid {
+    async fn parse_from_multipart(field: Option<Field>) -> ParseResult<Self> {
+        match field {
+            Some(field) => Ok(field.text().await?.parse()?),
+            None => Err(ParseError::expected_input()),
+        }
+    }
+}
+
+impl ToJSON for Ulid {
+    fn to_json(&self) -> Option<Value> {
+        Some(Value::String(self.to_string()))
+    }
+}
+
+impl ToHeader for Ulid {
+    fn to_header(&self) -> Option<HeaderValue> {
+        HeaderValue::from_str(&self.to_string()).ok()
+    }
+}


### PR DESCRIPTION
Adds `Type`, `ParseFromJSON`, `ParseFromParameter`, `ParseFromMultipartField`, `ToJSON`, and `ToHeader` trait implementations for `ulid::Ulid`.