### PR TITLE
fix(openapi): use standard OpenAPI format with min/max for unsigned integers

### DIFF
--- a/poem-openapi/src/types/external/integers.rs
+++ b/poem-openapi/src/types/external/integers.rs
@@ -127,7 +127,7 @@ macro_rules! impl_type_for_integers {
 }
 
 macro_rules! impl_type_for_unsigneds {
-    ($(($ty:ty, $format:literal)),*) => {
+    ($(($ty:ty, $format:literal, $min:expr, $max:expr)),*) => {
         $(
         impl Type for $ty {
             const IS_REQUIRED: bool = true;
@@ -141,7 +141,13 @@ macro_rules! impl_type_for_unsigneds {
             }
 
             fn schema_ref() -> MetaSchemaRef {
-                MetaSchemaRef::Inline(Box::new(MetaSchema::new_with_format("integer", $format)))
+                MetaSchemaRef::Inline(Box::new(MetaSchema {
+                    ty: "integer",
+                    format: Some($format),
+                    minimum: Some($min),
+                    maximum: Some($max),
+                    ..MetaSchema::ANY
+                }))
             }
 
             fn as_raw_value(&self) -> Option<&Self::RawValueType> {
@@ -215,9 +221,9 @@ macro_rules! impl_type_for_unsigneds {
 impl_type_for_integers!((i8, "int8"), (i16, "int16"), (i32, "int32"), (i64, "int64"));
 
 impl_type_for_unsigneds!(
-    (u8, "uint8"),
-    (u16, "uint16"),
-    (u32, "uint32"),
-    (u64, "uint64"),
-    (usize, "uint64")
+    (u8, "int32", 0.0, u8::MAX as f64),
+    (u16, "int32", 0.0, u16::MAX as f64),
+    (u32, "int64", 0.0, u32::MAX as f64),
+    (u64, "int64", 0.0, u64::MAX as f64),
+    (usize, "int64", 0.0, u64::MAX as f64)
 );

--- a/poem-openapi/src/types/external/non_zero.rs
+++ b/poem-openapi/src/types/external/non_zero.rs
@@ -100,7 +100,7 @@ macro_rules! impl_type_for_non_zero_integers {
 }
 
 macro_rules! impl_type_for_non_zero_unsigneds {
-    ($(($ty:ty, $format:literal)),*) => {
+    ($(($ty:ty, $format:literal, $max:expr)),*) => {
         $(
         impl Type for NonZero<$ty> {
             const IS_REQUIRED: bool = true;
@@ -115,10 +115,11 @@ macro_rules! impl_type_for_non_zero_unsigneds {
 
             fn schema_ref() -> MetaSchemaRef {
                 MetaSchemaRef::Inline(Box::new(MetaSchema {
-                    ty: "non_zero_integer",
+                    ty: "integer",
                     format: Some($format),
                     minimum: Some(0.0),
                     exclusive_minimum: Some(true),
+                    maximum: Some($max),
                     ..MetaSchema::ANY
                 }))
             }
@@ -181,9 +182,9 @@ macro_rules! impl_type_for_non_zero_unsigneds {
 impl_type_for_non_zero_integers!((i8, "int8"), (i16, "int16"), (i32, "int32"), (i64, "int64"));
 
 impl_type_for_non_zero_unsigneds!(
-    (u8, "uint8"),
-    (u16, "uint16"),
-    (u32, "uint32"),
-    (u64, "uint64"),
-    (usize, "uint64")
+    (u8, "int32", u8::MAX as f64),
+    (u16, "int32", u16::MAX as f64),
+    (u32, "int64", u32::MAX as f64),
+    (u64, "int64", u64::MAX as f64),
+    (usize, "int64", u64::MAX as f64)
 );

--- a/poem-openapi/tests/api.rs
+++ b/poem-openapi/tests/api.rs
@@ -469,7 +469,7 @@ async fn bad_request_handler() {
     resp.assert_status(StatusCode::BAD_REQUEST);
     resp.assert_content_type("text/plain; charset=utf-8");
     resp.assert_text(
-        r#"!!! failed to parse parameter `code`: Type "integer(uint16)" expects an input value."#,
+        r#"!!! failed to parse parameter `code`: Type "integer(int32)" expects an input value."#,
     )
     .await;
 }

--- a/poem-openapi/tests/validation.rs
+++ b/poem-openapi/tests/validation.rs
@@ -48,7 +48,7 @@ fn test_non_zero_u64() {
         A::parse_from_json(Some(json!({ "n": 0 })))
             .unwrap_err()
             .into_message(),
-        "failed to parse \"non_zero_integer(uint64)\": Integer should not be 0. (occurred while parsing \"A\")"
+        "failed to parse \"non_zero_integer(int64)\": Integer should not be 0. (occurred while parsing \"A\")"
     );
 }
 
@@ -495,7 +495,7 @@ fn test_unsigned_integers() {
         })))
         .unwrap_err()
         .into_message(),
-        "failed to parse \"integer(uint8)\": Only integers from 0 to 255 are accepted. (occurred while parsing \"A\")"
+        "failed to parse \"integer(int32)\": Only integers from 0 to 255 are accepted. (occurred while parsing \"A\")"
     );
 }
 
@@ -764,4 +764,47 @@ fn test_custom_validator() {
         .into_message(),
         "failed to parse \"A\": field `value` verification failed. MyIntValidator"
     );
+}
+
+#[test]
+fn test_unsigned_integer_schema() {
+    // Test that unsigned integers use standard OpenAPI formats with minimum/maximum constraints
+    // instead of non-standard uint* formats
+
+    let schema_u8 = u8::schema_ref();
+    let schema_u8 = schema_u8.unwrap_inline();
+    assert_eq!(schema_u8.ty, "integer");
+    assert_eq!(schema_u8.format, Some("int32"));
+    assert_eq!(schema_u8.minimum, Some(0.0));
+    assert_eq!(schema_u8.maximum, Some(u8::MAX as f64));
+
+    let schema_u16 = u16::schema_ref();
+    let schema_u16 = schema_u16.unwrap_inline();
+    assert_eq!(schema_u16.ty, "integer");
+    assert_eq!(schema_u16.format, Some("int32"));
+    assert_eq!(schema_u16.minimum, Some(0.0));
+    assert_eq!(schema_u16.maximum, Some(u16::MAX as f64));
+
+    let schema_u32 = u32::schema_ref();
+    let schema_u32 = schema_u32.unwrap_inline();
+    assert_eq!(schema_u32.ty, "integer");
+    assert_eq!(schema_u32.format, Some("int64"));
+    assert_eq!(schema_u32.minimum, Some(0.0));
+    assert_eq!(schema_u32.maximum, Some(u32::MAX as f64));
+
+    let schema_u64 = u64::schema_ref();
+    let schema_u64 = schema_u64.unwrap_inline();
+    assert_eq!(schema_u64.ty, "integer");
+    assert_eq!(schema_u64.format, Some("int64"));
+    assert_eq!(schema_u64.minimum, Some(0.0));
+    assert_eq!(schema_u64.maximum, Some(u64::MAX as f64));
+
+    // Test NonZero unsigned integers have minimum > 0 (exclusive)
+    let schema_nz_u64 = NonZero::<u64>::schema_ref();
+    let schema_nz_u64 = schema_nz_u64.unwrap_inline();
+    assert_eq!(schema_nz_u64.ty, "integer");
+    assert_eq!(schema_nz_u64.format, Some("int64"));
+    assert_eq!(schema_nz_u64.minimum, Some(0.0));
+    assert_eq!(schema_nz_u64.exclusive_minimum, Some(true));
+    assert_eq!(schema_nz_u64.maximum, Some(u64::MAX as f64));
 }


### PR DESCRIPTION
## Summary

- Fixes #760: Use standard OpenAPI formats (`int32`/`int64`) with `minimum`/`maximum` constraints for unsigned integers instead of non-standard `uint*` formats

## Changes

Previously, unsigned integer types (`u8`, `u16`, `u32`, `u64`, `usize`) used non-standard format values like `uint16`, `uint32`, `uint64` in the generated OpenAPI schema. These formats are not part of the OpenAPI specification and can cause issues with code generators and validators.

This change:
- Uses standard `int32` format for `u8` and `u16` (they fit in 32 bits)
- Uses standard `int64` format for `u32`, `u64`, and `usize`
- Adds `minimum: 0` constraint to indicate unsigned values
- Adds `maximum` constraint with the type's max value (e.g., 255 for `u8`, 65535 for `u16`)
- Applies the same fix to `NonZero<uX>` types with `exclusive_minimum: true`

### Before
```yaml
MyStructure:
  type: object
  properties:
    a:
      type: integer
      format: uint64
    b:
      type: integer
      format: uint16
```

### After
```yaml
MyStructure:
  type: object
  properties:
    a:
      type: integer
      format: int64
      minimum: 0
      maximum: 18446744073709551615
    b:
      type: integer
      format: int32
      minimum: 0
      maximum: 65535
```

## Testing

Added `test_unsigned_integer_schema` test to verify the schema has correct `minimum` and `maximum` values for all unsigned integer types.">