### PR TITLE
Sanitize generic type names to be valid OpenAPI identifiers

### DIFF
--- a/poem-openapi-derive/src/utils.rs
+++ b/poem-openapi-derive/src/utils.rs
@@ -194,10 +194,10 @@ pub(crate) fn create_object_name(
             let mut name = ::std::string::String::from(#name);
 
             name.push('_');
-            name.push_str(&<#first as #crate_name::types::Type>::name());
+            name.push_str(&#crate_name::types::sanitize_type_name(&<#first as #crate_name::types::Type>::name()));
             #(
                 name.push_str("_");
-                name.push_str(&<#tail as #crate_name::types::Type>::name());
+                name.push_str(&#crate_name::types::sanitize_type_name(&<#tail as #crate_name::types::Type>::name()));
             )*
 
             name


### PR DESCRIPTION
## Summary

- Fixes #519 - `$ref` values must be RFC3986-compliant percent-encoded URIs
- Fixes #318 - Generics produce invalid OpenAPI identifiers

## Problem

Generic types like `PaginatedResponse<SessionSnapshot>` produce type names containing `<>` characters, which are invalid according to the OpenAPI specification. The spec states:

> Component names can only contain the characters A-Z a-z 0-9 - . _

This causes errors like "$ref values must be RFC3986-compliant percent-encoded URIs" when validating the OpenAPI spec.

## Solution

Added a `sanitize_type_name` function in `poem_openapi::types` that:
- Replaces invalid characters (`<`, `>`, `,`, `:`, space) with underscores
- Removes consecutive underscores  
- Trims leading/trailing underscores

The sanitization is applied in `create_object_name` when building names for generic Object and Union types.

## Examples

| Before | After |
|--------|-------|
| `Generic<Inner>` | `Generic_Inner` |
| `Complex<A, B>` | `Complex_A_B` |
| `path::to::Type` | `path_to_Type` |
| `A<B<C>>` | `A_B_C` |

## Testing

- Added unit tests for the sanitization function
- Added integration tests verifying generic Object types produce valid OpenAPI names
- All existing tests pass