### PR TITLE
Add example attribute support to Union derive macro

### DIFF
--- a/poem-openapi/src/docs/union.md
+++ b/poem-openapi/src/docs/union.md
@@ -9,6 +9,7 @@ Define an OpenAPI discriminator object.
 | one_of             | Validates the value against exactly one of the subschemas                                                                                                                                                                    | bool   | Y        |
 | external_docs      | Specify a external resource for extended documentation                                                                                                                                                                       | string | Y        |
 | rename_all         | Rename all the mapping name according to the given case convention. The possible values are "lowercase", "UPPERCASE", "PascalCase", "camelCase", "snake_case", "SCREAMING_SNAKE_CASE", "kebab-case", "SCREAMING-KEBAB-CASE". | string | Y        |
+| example            | Indicates that the type has implemented `Example` trait                                                                                                                                                                      | bool   | Y        |
 
 # Item parameters
 


### PR DESCRIPTION
## Summary

- Fixes #960 - Union not a full member, yet, example is not supported

## Problem

The Union derive macro was missing support for the `example` attribute that allows providing example values in the OpenAPI schema. This attribute was already supported by the Object derive macro, but trying to use it on Union would fail to compile.

## Solution

Added the `example` attribute to Union following the same pattern as Object:

1. Added `example: bool` field to `UnionArgs` struct
2. When `example = true`:
   - Adds `Self: Example` bound to the where clause
   - Generates code to call `Example::example()` and convert to JSON
   - Sets `meta.example` in the schema registration

## Usage

```rust
use poem_openapi::{Union, Object, types::Example};

#[derive(Object)]
struct Dog {
    name: String,
}

#[derive(Union)]
#[oai(discriminator_name = "type", example)]
enum Pet {
    Dog(Dog),
}

impl Example for Pet {
    fn example() -> Self {
        Pet::Dog(Dog { name: "Max".to_string() })
    }
}
```

## Tests Added

- `with_example`: Tests Union with discriminator and example
- `with_example_no_discriminator`: Tests Union without discriminator but with example