### PR TITLE
Fix Option<T> ToJSON to return None instead of null

### DIFF
--- a/poem-openapi/src/types/external/optional.rs
+++ b/poem-openapi/src/types/external/optional.rs
@@ -99,7 +99,7 @@ impl<T: ToJSON> ToJSON for Option<T> {
     fn to_json(&self) -> Option<Value> {
         match self {
             Some(value) => value.to_json(),
-            None => Some(Value::Null),
+            None => None,
         }
     }
 }

--- a/poem-openapi/src/types/mod.rs
+++ b/poem-openapi/src/types/mod.rs
@@ -501,4 +501,30 @@ mod tests {
             Some(Value::Number(100.into()))
         );
     }
+
+    #[test]
+    fn option_type() {
+        // Option<T> where T is present should serialize to the inner value
+        let some_value: Option<i32> = Some(42);
+        assert_eq!(ToJSON::to_json(&some_value), Some(Value::Number(42.into())));
+
+        // Option<T> where T is None should serialize to None (field omitted)
+        // This matches the OpenAPI spec where the field is not required
+        // and should be absent rather than null when not present
+        let none_value: Option<i32> = None;
+        assert_eq!(ToJSON::to_json(&none_value), None);
+
+        // Test with nested Option
+        let nested_some: Option<Option<i32>> = Some(Some(42));
+        assert_eq!(
+            ToJSON::to_json(&nested_some),
+            Some(Value::Number(42.into()))
+        );
+
+        let nested_none: Option<Option<i32>> = Some(None);
+        assert_eq!(ToJSON::to_json(&nested_none), None);
+
+        let outer_none: Option<Option<i32>> = None;
+        assert_eq!(ToJSON::to_json(&outer_none), None);
+    }
 }


### PR DESCRIPTION
## Summary

- Fixes #913 - Poem openapi Option<T> ToJSON & Type implementation mismatch

## Problem

The `ToJSON` implementation for `Option<T>` was returning `Some(Value::Null)` when the value was `None`:

```rust
impl<T: ToJSON> ToJSON for Option<T> {
    fn to_json(&self) -> Option<Value> {
        match self {
            Some(value) => value.to_json(),
            None => Some(Value::Null),  // This causes the field to be present with null value
        }
    }
}
```

This creates a mismatch with the OpenAPI schema, which marks optional fields as not required (the field should be absent when not provided, not null).

**Before fix:**
```json
{ "optionalField": null }
```

**After fix:**
```json
{ }
```

## Solution

Changed the `ToJSON` implementation to return `None` when the inner value is `None`, causing the field to be omitted from the JSON output:

```rust
impl<T: ToJSON> ToJSON for Option<T> {
    fn to_json(&self) -> Option<Value> {
        match self {
            Some(value) => value.to_json(),
            None => None,  // Field will be omitted from JSON
        }
    }
}
```

This matches the OpenAPI spec semantics where:
- Required fields must be present
- Optional (not required) fields may be absent entirely

## Tests Added

Added unit tests to verify:
- `Some(value)` serializes to the inner value
- `None` serializes to `None` (field omitted)
- Nested `Option<Option<T>>` works correctly