### PR TITLE
docs: document trait object usage with Data extractor

### DIFF
--- a/poem/src/middleware/add_data.rs
+++ b/poem/src/middleware/add_data.rs
@@ -7,6 +7,40 @@ pub struct AddData<T> {
 
 impl<T: Clone + Send + Sync + 'static> AddData<T> {
     /// Create new `AddData` middleware with any value.
+    ///
+    /// # Using with Trait Objects
+    ///
+    /// When using trait objects, you must explicitly coerce the value to the
+    /// trait object type before passing it to this method. See the
+    /// [`Data`](crate::web::Data) extractor documentation for details.
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use poem::{Endpoint, EndpointExt, handler, middleware::AddData, test::TestClient, web::Data};
+    ///
+    /// trait Service: Send + Sync {
+    ///     fn name(&self) -> &str;
+    /// }
+    ///
+    /// struct MyService;
+    /// impl Service for MyService {
+    ///     fn name(&self) -> &str { "my_service" }
+    /// }
+    ///
+    /// #[handler]
+    /// async fn index(svc: Data<&Arc<dyn Service>>) -> String {
+    ///     svc.name().to_string()
+    /// }
+    ///
+    /// # tokio::runtime::Runtime::new().unwrap().block_on(async {
+    /// // Key: coerce to Arc<dyn Service> before passing to AddData::new
+    /// let svc: Arc<dyn Service> = Arc::new(MyService);
+    /// let cli = TestClient::new(index.with(AddData::new(svc)));
+    /// let resp = cli.get("/").send().await;
+    /// resp.assert_status_is_ok();
+    /// resp.assert_text("my_service").await;
+    /// # });
+    /// ```
     pub fn new(value: T) -> Self {
         AddData { value }
     }
@@ -48,8 +82,10 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
-    use crate::{EndpointExt, handler, test::TestClient};
+    use crate::{EndpointExt, handler, test::TestClient, web::Data};
 
     #[tokio::test]
     async fn test_add_data() {
@@ -60,5 +96,60 @@ mod tests {
 
         let cli = TestClient::new(index.with(AddData::new(100i32)));
         cli.get("/").send().await.assert_status_is_ok();
+    }
+
+    #[tokio::test]
+    async fn test_add_data_trait_object_with_arc() {
+        // Demonstrates how to use trait objects with Data extractor.
+        // Since Box<dyn Trait> doesn't implement Clone, we use Arc<dyn Trait>.
+        trait Database: Send + Sync {
+            fn name(&self) -> &str;
+        }
+
+        struct PostgresDb;
+        impl Database for PostgresDb {
+            fn name(&self) -> &str {
+                "postgres"
+            }
+        }
+
+        #[handler(internal)]
+        async fn index(db: Data<&Arc<dyn Database>>) -> String {
+            db.name().to_string()
+        }
+
+        // Key: explicitly coerce to Arc<dyn Database> before calling .data()
+        let db: Arc<dyn Database> = Arc::new(PostgresDb);
+        let cli = TestClient::new(index.data(db));
+        let resp = cli.get("/").send().await;
+        resp.assert_status_is_ok();
+        resp.assert_text("postgres").await;
+    }
+
+    #[tokio::test]
+    async fn test_add_data_middleware_trait_object() {
+        // Demonstrates using AddData middleware directly with trait objects.
+        trait Service: Send + Sync {
+            fn version(&self) -> u32;
+        }
+
+        struct MyService;
+        impl Service for MyService {
+            fn version(&self) -> u32 {
+                42
+            }
+        }
+
+        #[handler(internal)]
+        async fn index(svc: Data<&Arc<dyn Service>>) -> String {
+            svc.version().to_string()
+        }
+
+        // Explicitly coerce to trait object type, then use AddData::new
+        let svc: Arc<dyn Service> = Arc::new(MyService);
+        let cli = TestClient::new(index.with(AddData::new(svc)));
+        let resp = cli.get("/").send().await;
+        resp.assert_status_is_ok();
+        resp.assert_text("42").await;
     }
 }


### PR DESCRIPTION
## Summary
- Documents the fundamental Rust TypeId limitation that causes `Data<&Box<dyn Trait>>` extraction to fail when data is stored with a concrete type
- Provides clear examples showing the correct way to use trait objects with the Data extractor

Fixes #955

## The Issue

When using trait objects with the `Data` extractor, this pattern fails:

```rust
// This stores with TypeId::of::<Arc<PostgresDb>>()
let app = endpoint.data(Arc::new(PostgresDb));

// This looks for TypeId::of::<Arc<dyn Database>>() - different TypeId!
async fn handler(db: Data<&Arc<dyn Database>>) { ... }
```

The error is:
> data of type `alloc::sync::Arc<dyn Database>` was not found.

## The Solution

Explicitly coerce to the trait object type before storing:

```rust
// Key: coerce to Arc<dyn Database> before calling .data()
let db: Arc<dyn Database> = Arc::new(PostgresDb);
let app = endpoint.data(db);

// Now extraction works!
async fn handler(db: Data<&Arc<dyn Database>>) { ... }
```

Note: Use `Arc<dyn Trait>` rather than `Box<dyn Trait>` because the stored type must implement `Clone`.

## Changes

- Added comprehensive documentation to `Data` extractor explaining the TypeId limitation
- Updated `EndpointExt::data()` docs with trait object examples
- Updated `AddData::new()` docs with trait object examples
- Added unit tests demonstrating proper trait object usage