### PR TITLE
fix(openapi): improve Form payload to support arrays with serde_html_form

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ serde_yaml = "0.9"
 quick-xml = { version = "0.36.1", features = ["serialize"] }
 base64 = "0.22.0"
 serde_urlencoded = "0.7.1"
+serde_html_form = "0.2"
 indexmap = "2.0.0"
 reqwest = { version = "0.12.2", default-features = false }
 darling = "0.20.10"

--- a/poem-openapi/Cargo.toml
+++ b/poem-openapi/Cargo.toml
@@ -45,6 +45,7 @@ serde_json.workspace = true
 serde_yaml.workspace = true
 quick-xml.workspace = true
 serde_urlencoded.workspace = true
+serde_html_form.workspace = true
 base64.workspace = true
 serde.workspace = true
 derive_more = { version = "2.0", features = ["display"] }

--- a/poem-openapi/tests/payload.rs
+++ b/poem-openapi/tests/payload.rs
@@ -1,8 +1,8 @@
 use poem::{Error, http::StatusCode, test::TestClient};
 use poem_openapi::{
-    ApiResponse, OpenApi, OpenApiService,
+    ApiResponse, Object, OpenApi, OpenApiService,
     param::Query,
-    payload::{Json, Response},
+    payload::{Form, Json, Response},
 };
 
 #[tokio::test]
@@ -50,4 +50,97 @@ async fn response_wrapper() {
     let resp = cli.get("/b").send().await;
     resp.assert_status(StatusCode::BAD_REQUEST);
     resp.assert_header("MY-HEADER1", "def");
+}
+
+#[tokio::test]
+async fn form_simple() {
+    #[derive(Debug, serde::Deserialize, Object)]
+    struct LoginForm {
+        username: String,
+        password: String,
+    }
+
+    struct Api;
+
+    #[OpenApi]
+    impl Api {
+        #[oai(path = "/login", method = "post")]
+        async fn login(&self, form: Form<LoginForm>) -> Json<String> {
+            Json(format!("user: {}", form.username))
+        }
+    }
+
+    let ep = OpenApiService::new(Api, "test", "1.0");
+    let cli = TestClient::new(ep);
+
+    let resp = cli
+        .post("/login")
+        .content_type("application/x-www-form-urlencoded")
+        .body("username=alice&password=secret")
+        .send()
+        .await;
+    resp.assert_status_is_ok();
+    resp.assert_json("user: alice").await;
+}
+
+#[tokio::test]
+async fn form_with_array() {
+    #[derive(Debug, serde::Deserialize, Object)]
+    struct IdsRequest {
+        ids: Vec<u32>,
+    }
+
+    struct Api;
+
+    #[OpenApi]
+    impl Api {
+        #[oai(path = "/items", method = "post")]
+        async fn get_items(&self, form: Form<IdsRequest>) -> Json<Vec<u32>> {
+            Json(form.ids.clone())
+        }
+    }
+
+    let ep = OpenApiService::new(Api, "test", "1.0");
+    let cli = TestClient::new(ep);
+
+    // Test with multiple values using repeated keys (correct format)
+    let resp = cli
+        .post("/items")
+        .content_type("application/x-www-form-urlencoded")
+        .body("ids=123&ids=456&ids=789")
+        .send()
+        .await;
+    resp.assert_status_is_ok();
+    resp.assert_json(&[123u32, 456, 789]).await;
+}
+
+#[tokio::test]
+async fn form_array_single_value() {
+    #[derive(Debug, serde::Deserialize, Object)]
+    struct IdsRequest {
+        ids: Vec<u32>,
+    }
+
+    struct Api;
+
+    #[OpenApi]
+    impl Api {
+        #[oai(path = "/items", method = "post")]
+        async fn get_items(&self, form: Form<IdsRequest>) -> Json<Vec<u32>> {
+            Json(form.ids.clone())
+        }
+    }
+
+    let ep = OpenApiService::new(Api, "test", "1.0");
+    let cli = TestClient::new(ep);
+
+    // Test with single value - serde_html_form supports this
+    let resp = cli
+        .post("/items")
+        .content_type("application/x-www-form-urlencoded")
+        .body("ids=123")
+        .send()
+        .await;
+    resp.assert_status_is_ok();
+    resp.assert_json(&[123u32]).await;
 }


### PR DESCRIPTION
## Summary

- Replace `serde_urlencoded` with `serde_html_form` for parsing Form payloads
- This fixes the issue where Form data with `Vec` fields would always return 400 Bad Request

## Details

`serde_urlencoded` does not support deserializing repeated keys into Vec types at all. For example, `ids=123&ids=456` would fail to parse into `Vec<u32>`.

`serde_html_form` properly handles HTML form encoding:
- Single values for array fields (`ids=123` -> `vec![123]`)
- Multiple values with repeated keys (`ids=123&ids=456` -> `vec![123, 456]`)

## Changes

- Add `serde_html_form` dependency to workspace and poem-openapi
- Update `Form` payload to use `serde_html_form::from_bytes` instead of `serde_urlencoded::from_bytes`
- Add comprehensive documentation explaining Form usage and limitations
- Add tests for Form with simple fields and array fields

Fixes #649