### PR TITLE
feat: support regex patterns in nest and nest_no_strip paths

### DIFF
--- a/poem/src/route/router.rs
+++ b/poem/src/route/router.rs
@@ -237,28 +237,64 @@ impl Route {
         struct Nest<T> {
             inner: T,
             root: bool,
+            /// For static paths, this is the prefix length to strip.
+            /// For dynamic paths (has_dynamic_prefix=true), this is the static
+            /// prefix length before any dynamic segment.
             prefix_len: usize,
-            prefix_for_path_pattern: usize,
+            /// The prefix length for path pattern slicing.
+            /// None for dynamic patterns in nest_no_strip mode.
+            prefix_for_path_pattern: Option<usize>,
+            /// Whether the nest path contains dynamic segments (regex
+            /// patterns).
+            has_dynamic_prefix: bool,
         }
 
         impl<E: Endpoint> Endpoint for Nest<E> {
             type Output = Response;
 
             async fn call(&self, mut req: Request) -> Result<Self::Output> {
-                if !self.root {
+                let rest_path_len = if !self.root {
                     let params = &mut req.state_mut().match_params;
                     if params.last().map(|(name, _)| name.as_str()) != Some("--poem-rest") {
                         return Err(ParsePathError.into());
                     }
 
-                    params.pop().expect("can't be empty due to a check above");
-                }
+                    let (_, rest_value) =
+                        params.pop().expect("can't be empty due to a check above");
+                    Some(rest_value.len())
+                } else {
+                    None
+                };
+
+                // Calculate actual prefix length to strip from the URI.
+                // For nest_no_strip (prefix_len = 0), we don't strip anything.
+                // For nest with dynamic patterns, we calculate based on the matched path.
+                let actual_prefix_len = if self.prefix_len == 0 {
+                    // nest_no_strip mode - don't strip anything
+                    0
+                } else if self.has_dynamic_prefix {
+                    // nest mode with dynamic patterns - calculate prefix from matched path
+                    if let Some(rest_len) = rest_path_len {
+                        let uri_path = req.uri().path();
+                        // The rest path doesn't include the leading slash, so we need to
+                        // account for that. Prefix = total_len - rest_len - 1 (for the /)
+                        // But we want to strip the prefix including the trailing slash.
+                        uri_path.len().saturating_sub(rest_len).saturating_sub(1)
+                    } else {
+                        // Root match - strip everything except the trailing character
+                        // For root matches on dynamic paths, the whole path is the prefix
+                        req.uri().path().len()
+                    }
+                } else {
+                    // nest mode with static patterns - use pre-calculated prefix
+                    self.prefix_len
+                };
 
                 let new_uri = {
                     let uri = std::mem::take(req.uri_mut());
                     let mut uri_parts = uri.into_parts();
                     let path =
-                        &uri_parts.path_and_query.as_ref().unwrap().as_str()[self.prefix_len..];
+                        &uri_parts.path_and_query.as_ref().unwrap().as_str()[actual_prefix_len..];
                     uri_parts.path_and_query = Some(if !path.starts_with('/') {
                         PathAndQuery::from_str(&format!("/{path}")).unwrap()
                     } else {
@@ -268,7 +304,9 @@ impl Route {
                 };
                 *req.uri_mut() = new_uri;
 
-                req.set_data(PathPrefix(self.prefix_for_path_pattern));
+                if let Some(prefix) = self.prefix_for_path_pattern {
+                    req.set_data(PathPrefix(prefix));
+                }
                 Ok(self.inner.call(req).await?.into_response())
             }
         }
@@ -277,22 +315,33 @@ impl Route {
             path.find('*').is_none(),
             "wildcards are not allowed in the nest path."
         );
-        assert!(
-            path.find(':').is_none(),
-            "captures are not allowed in the nest path."
-        );
-        assert!(
-            path.find('<').is_none(),
-            "regexs are not allowed in the nest path."
-        );
+
+        // Check if path contains dynamic segments (regex patterns or named params)
+        let has_dynamic_prefix = path.contains('<') || path.contains(':');
+
+        // Calculate the static prefix length (before any dynamic segment)
+        let static_prefix_len = if has_dynamic_prefix {
+            // Find the first dynamic segment (either regex < or param :)
+            let regex_pos = path.find('<').unwrap_or(path.len());
+            let param_pos = path.find(':').unwrap_or(path.len());
+            regex_pos.min(param_pos)
+        } else {
+            path.len() - 1 // Exclude trailing slash
+        };
 
         let prefix_len = match strip {
             false => 0,
+            true if has_dynamic_prefix => static_prefix_len,
             true => path.len() - 1,
         };
-        let prefix_for_path_pattern = match strip {
-            false => path.len() - 1,
-            true => 0,
+
+        // For nest_no_strip with dynamic patterns, we can't use a fixed prefix
+        // because the pattern length doesn't match the actual matched path length.
+        // In this case, we use None to signal that no prefix slicing should be done.
+        let prefix_for_path_pattern = match (strip, has_dynamic_prefix) {
+            (true, _) => Some(0),  // nest: no prefix needed for inner pattern
+            (false, true) => None, // nest_no_strip with dynamic: skip prefix mechanism
+            (false, false) => Some(path.len() - 1), // nest_no_strip with static: use pattern length
         };
 
         self.tree.add(
@@ -302,6 +351,7 @@ impl Route {
                 root: false,
                 prefix_len,
                 prefix_for_path_pattern,
+                has_dynamic_prefix,
             }
             .boxed(),
         )?;
@@ -313,6 +363,7 @@ impl Route {
                 root: true,
                 prefix_len,
                 prefix_for_path_pattern,
+                has_dynamic_prefix,
             }
             .boxed(),
         )?;
@@ -780,5 +831,141 @@ mod tests {
             spy.last_pattern().await,
             "/nest_no_strip1/nest_no_strip2/:id"
         );
+    }
+
+    #[tokio::test]
+    async fn nested_with_regex() {
+        // Test nest with regex pattern - issue #490
+        let r = Route::new().nest("/<(api|oauth)>", Route::new().at("/a", h).at("/b", h));
+
+        // Both /api and /oauth should work and strip the prefix correctly
+        assert_eq!(get(&r, "/api/a").await, "/a");
+        assert_eq!(get(&r, "/api/b").await, "/b");
+        assert_eq!(get(&r, "/oauth/a").await, "/a");
+        assert_eq!(get(&r, "/oauth/b").await, "/b");
+
+        // Test that other paths don't match
+        let result = r
+            .call(
+                Request::builder()
+                    .uri(Uri::from_static("/other/a"))
+                    .finish(),
+            )
+            .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn nested_no_strip_with_regex() {
+        // Test nest_no_strip with regex pattern - issue #490
+        let r = Route::new().nest_no_strip(
+            "/<(api|oauth)>",
+            Route::new().at("/api/a", h).at("/oauth/a", h),
+        );
+
+        // Both /api and /oauth should work without stripping
+        assert_eq!(get(&r, "/api/a").await, "/api/a");
+        assert_eq!(get(&r, "/oauth/a").await, "/oauth/a");
+    }
+
+    #[tokio::test]
+    async fn nested_with_regex_and_static_prefix() {
+        // Test regex pattern with a static prefix
+        let r = Route::new().nest("/v1/<(public|private)>", Route::new().at("/data", h));
+
+        assert_eq!(get(&r, "/v1/public/data").await, "/data");
+        assert_eq!(get(&r, "/v1/private/data").await, "/data");
+    }
+
+    #[tokio::test]
+    async fn nested_regex_multiple_segments() {
+        // Test regex pattern matching multiple possibilities
+        let r = Route::new().nest(
+            "/<(v1|v2|v3)>/<(users|accounts)>",
+            Route::new().at("/list", h),
+        );
+
+        assert_eq!(get(&r, "/v1/users/list").await, "/list");
+        assert_eq!(get(&r, "/v2/accounts/list").await, "/list");
+        assert_eq!(get(&r, "/v3/users/list").await, "/list");
+    }
+
+    #[tokio::test]
+    async fn nested_with_named_param() {
+        // Test nest with named path parameter (no regex)
+        let r = Route::new().nest("/:version", Route::new().at("/users", h));
+
+        assert_eq!(get(&r, "/v1/users").await, "/users");
+        assert_eq!(get(&r, "/v2/users").await, "/users");
+        assert_eq!(get(&r, "/anything/users").await, "/users");
+    }
+
+    #[tokio::test]
+    async fn nested_with_named_regex() {
+        // Test nest with named regex capture - issue #490 enhancement
+        let r = Route::new().nest(
+            "/:version<(v1|v2)>",
+            Route::new().at("/users", h).at("/data", h),
+        );
+
+        assert_eq!(get(&r, "/v1/users").await, "/users");
+        assert_eq!(get(&r, "/v2/data").await, "/data");
+
+        // Non-matching versions should fail
+        let result = r
+            .call(
+                Request::builder()
+                    .uri(Uri::from_static("/v3/users"))
+                    .finish(),
+            )
+            .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn nested_named_param_available_to_handler() {
+        // Test that named params from nest prefix are available to handlers
+        #[handler(internal)]
+        fn handler_with_params(req: &Request) -> String {
+            let params = &req.state().match_params;
+            params
+                .iter()
+                .map(|(k, v)| format!("{}={}", k, v))
+                .collect::<Vec<_>>()
+                .join(",")
+        }
+
+        let r = Route::new().nest(
+            "/:version<(v1|v2)>",
+            Route::new().at("/info", handler_with_params),
+        );
+
+        // The version param should be available
+        let resp = r
+            .call(
+                Request::builder()
+                    .uri(Uri::from_static("/v1/info"))
+                    .finish(),
+            )
+            .await
+            .unwrap();
+        let body = resp.into_body().into_string().await.unwrap();
+        assert!(
+            body.contains("version=v1"),
+            "Expected version=v1, got: {}",
+            body
+        );
+    }
+
+    #[tokio::test]
+    async fn nested_no_strip_with_named_param() {
+        // Test nest_no_strip with named param
+        let r = Route::new().nest_no_strip(
+            "/:version",
+            Route::new().at("/v1/users", h).at("/v2/users", h),
+        );
+
+        assert_eq!(get(&r, "/v1/users").await, "/v1/users");
+        assert_eq!(get(&r, "/v2/users").await, "/v2/users");
     }
 }


### PR DESCRIPTION
## Summary
- Adds support for dynamic path patterns in nested routes (closes #490)
- Supports anonymous regex, named params, and named regex patterns

## Supported Patterns

```rust
// Anonymous regex - matches /api/users or /oauth/users
let app = Route::new().nest(
    "/<(api|oauth)>",
    Route::new().at("/users", handler),
);

// Named param - matches /v1/users, /v2/users, /anything/users
let app = Route::new().nest(
    "/:version",
    Route::new().at("/users", handler),
);

// Named regex - matches only /v1/users or /v2/users
let app = Route::new().nest(
    "/:version<(v1|v2)>",
    Route::new().at("/users", handler),
);

// Static prefix + regex
let app = Route::new().nest(
    "/api/:version<(v1|v2)>",
    Route::new().at("/data", handler),
);
```

## Key Features
- Named params from the nest prefix are preserved in `match_params` and available to nested handlers
- Works with both `nest()` (strips prefix) and `nest_no_strip()` (preserves full path)
- Dynamic prefix length is calculated at runtime based on the actual matched path

## Changes
- Removed asserts that blocked regex (`<...>`) and param (`:name`) patterns in nest paths
- Added dynamic prefix length calculation using the rest path from the catch-all match
- Updated `PathPrefix` handling to use `Option<usize>` for dynamic patterns

## Tests
- Anonymous regex nesting
- Named param nesting  
- Named regex nesting
- Verifying params are available to nested handlers
- `nest_no_strip` with dynamic patterns
- Multiple regex segments