### PR TITLE
fix: properly generate OpenAPI schema for flattened Union types

### DIFF
--- a/poem-openapi/src/registry/mod.rs
+++ b/poem-openapi/src/registry/mod.rs
@@ -185,6 +185,12 @@ impl MetaSchema {
         self == &Self::ANY
     }
 
+    /// Returns true if this schema uses `oneOf` or `anyOf` composition.
+    /// This is typically the case for Union types.
+    pub fn is_union(&self) -> bool {
+        !self.one_of.is_empty() || !self.any_of.is_empty()
+    }
+
     #[must_use]
     pub fn merge(
         mut self,


### PR DESCRIPTION
## Summary
- Fixes issue #945: OpenAPI Union does not properly use flatten in documentation

## Problem
When a Union type (using `oneOf`/`anyOf`) was flattened into an Object, the generated OpenAPI schema was incorrect. The Object derive macro was trying to extend `properties` from the Union's schema, but Union schemas have `oneOf`/`anyOf` instead of `properties`.

## Solution
The fix detects when a flattened field is a Union type and uses `allOf` composition instead:

```yaml
# Before (broken):
Flatten:
  type: object
  properties:
    other:
      type: string
  # Missing the Union fields!

# After (correct):
Flatten:
  allOf:
    - $ref: '#/components/schemas/UnionEnum'  # The Union
    - type: object
      properties:
        other:
          type: string
```

## Changes
- Added `is_union()` helper method to `MetaSchema` to detect Union types
- Modified Object derive macro to check if flattened types are Unions
- For Union types: adds the Union reference to `allOf`
- For regular Object types: continues to extend properties as before

## Example Usage
```rust
#[derive(Union)]
#[oai(discriminator_name = "type")]
enum UnionEnum {
    ValueA(ValueA),
    ValueB(ValueB),
}

#[derive(Object)]
struct Flatten {
    #[oai(flatten)]
    inner: UnionEnum,  // Now properly generates allOf schema
    other: String,
}
```