### PR TITLE
fix(openapi): preserve indentation in doc comment code blocks

### DIFF
--- a/poem-openapi-derive/src/utils.rs
+++ b/poem-openapi-derive/src/utils.rs
@@ -34,10 +34,16 @@ pub(crate) fn get_description(attrs: &[Attribute]) -> Result<Option<String>> {
                 }) = &nv.value
                 {
                     let doc = doc.value();
-                    let doc_str = doc.trim();
+                    // Only trim trailing whitespace to preserve indentation for code blocks.
+                    // Leading whitespace from the first space after `///` is handled below.
+                    let doc_str = doc.trim_end();
                     if !full_docs.is_empty() {
                         full_docs += "\n";
                     }
+                    // Doc comments typically have a leading space after `///`.
+                    // Strip exactly one leading space if present, preserving any additional
+                    // indentation for code blocks and other formatted content.
+                    let doc_str = doc_str.strip_prefix(' ').unwrap_or(doc_str);
                     full_docs += doc_str;
                 }
             }

--- a/poem-openapi/tests/object.rs
+++ b/poem-openapi/tests/object.rs
@@ -263,6 +263,29 @@ fn field_description() {
 }
 
 #[test]
+fn description_preserves_indentation() {
+    /// Example JSON:
+    ///
+    /// ```json
+    /// {
+    ///   "id": 1,
+    ///   "nested": {
+    ///     "value": "test"
+    ///   }
+    /// }
+    /// ```
+    #[derive(Object)]
+    struct Obj {
+        a: i32,
+    }
+
+    let meta = get_meta::<Obj>();
+    // Verify that the indentation within the code block is preserved
+    let expected = "Example JSON:\n\n```json\n{\n  \"id\": 1,\n  \"nested\": {\n    \"value\": \"test\"\n  }\n}\n```";
+    assert_eq!(meta.description, Some(expected));
+}
+
+#[test]
 fn field_default() {
     #[derive(Object, Debug, Eq, PartialEq)]
     struct Obj {


### PR DESCRIPTION
## Summary
- Fixes code block indentation being stripped in Swagger UI descriptions
- Doc comments with JSON examples and other formatted content now preserve their structure

## Problem
When using code blocks in doc comments, the indentation was being stripped:

```rust
/// Example:
/// ```json
/// {
///   "id": 1,
///   "nested": {
///     "value": "test"
///   }
/// }
/// ```
```

This rendered in Swagger UI without the indentation, making JSON examples hard to read.

## Solution
Changed `get_description()` in the derive macro to:
1. Use `trim_end()` instead of `trim()` to preserve leading whitespace
2. Strip exactly one leading space (the conventional space after `///`) while preserving any additional indentation

## Test
Added a test case `description_preserves_indentation` that verifies code block indentation is maintained.

Fixes #745