### PR TITLE
feat(openapi): use API title for UI page titles

### DIFF
--- a/poem-openapi/src/openapi.rs
+++ b/poem-openapi/src/openapi.rs
@@ -444,7 +444,7 @@ impl<T, W> OpenApiService<T, W> {
         T: OpenApi,
         W: Webhook,
     {
-        crate::ui::openapi_explorer::create_endpoint(self.spec())
+        crate::ui::openapi_explorer::create_endpoint(self.info.title.clone(), self.spec())
     }
 
     /// Create the OpenAPI Explorer HTML
@@ -454,7 +454,7 @@ impl<T, W> OpenApiService<T, W> {
         T: OpenApi,
         W: Webhook,
     {
-        crate::ui::openapi_explorer::create_html(&self.spec())
+        crate::ui::openapi_explorer::create_html(&self.info.title, &self.spec())
     }
 
     /// Create the Swagger UI endpoint.
@@ -465,7 +465,7 @@ impl<T, W> OpenApiService<T, W> {
         T: OpenApi,
         W: Webhook,
     {
-        crate::ui::swagger_ui::create_endpoint(self.spec())
+        crate::ui::swagger_ui::create_endpoint(self.info.title.clone(), self.spec())
     }
 
     /// Create the Swagger UI HTML
@@ -475,7 +475,7 @@ impl<T, W> OpenApiService<T, W> {
         T: OpenApi,
         W: Webhook,
     {
-        crate::ui::swagger_ui::create_html(&self.spec())
+        crate::ui::swagger_ui::create_html(&self.info.title, &self.spec())
     }
 
     /// Create the Rapidoc endpoint.
@@ -486,7 +486,7 @@ impl<T, W> OpenApiService<T, W> {
         T: OpenApi,
         W: Webhook,
     {
-        crate::ui::rapidoc::create_endpoint(self.spec())
+        crate::ui::rapidoc::create_endpoint(self.info.title.clone(), self.spec())
     }
 
     /// Create the Rapidoc HTML
@@ -496,7 +496,7 @@ impl<T, W> OpenApiService<T, W> {
         T: OpenApi,
         W: Webhook,
     {
-        crate::ui::rapidoc::create_html(&self.spec())
+        crate::ui::rapidoc::create_html(&self.info.title, &self.spec())
     }
 
     /// Create the Redoc endpoint.
@@ -507,7 +507,7 @@ impl<T, W> OpenApiService<T, W> {
         T: OpenApi,
         W: Webhook,
     {
-        crate::ui::redoc::create_endpoint(self.spec())
+        crate::ui::redoc::create_endpoint(self.info.title.clone(), self.spec())
     }
 
     /// Create the Redoc HTML
@@ -518,7 +518,7 @@ impl<T, W> OpenApiService<T, W> {
         T: OpenApi,
         W: Webhook,
     {
-        crate::ui::redoc::create_html(&self.spec())
+        crate::ui::redoc::create_html(&self.info.title, &self.spec())
     }
 
     /// Create the Scalar endpoint.
@@ -529,7 +529,7 @@ impl<T, W> OpenApiService<T, W> {
         T: OpenApi,
         W: Webhook,
     {
-        crate::ui::scalar::create_endpoint(self.spec())
+        crate::ui::scalar::create_endpoint(self.info.title.clone(), self.spec())
     }
 
     /// Create the Scalar HTML
@@ -540,7 +540,7 @@ impl<T, W> OpenApiService<T, W> {
         T: OpenApi,
         W: Webhook,
     {
-        crate::ui::scalar::create_html(&self.spec())
+        crate::ui::scalar::create_html(&self.info.title, &self.spec())
     }
 
     /// Create the Stoplight Elements endpoint.
@@ -551,7 +551,7 @@ impl<T, W> OpenApiService<T, W> {
         T: OpenApi,
         W: Webhook,
     {
-        crate::ui::stoplight_elements::create_endpoint(self.spec())
+        crate::ui::stoplight_elements::create_endpoint(self.info.title.clone(), self.spec())
     }
 
     /// Create the Stoplight Elements HTML.
@@ -562,7 +562,7 @@ impl<T, W> OpenApiService<T, W> {
         T: OpenApi,
         W: Webhook,
     {
-        crate::ui::stoplight_elements::create_html(&self.spec())
+        crate::ui::stoplight_elements::create_html(&self.info.title, &self.spec())
     }
 
     /// Create an endpoint to serve the open api specification as JSON.

--- a/poem-openapi/src/ui/openapi_explorer/mod.rs
+++ b/poem-openapi/src/ui/openapi_explorer/mod.rs
@@ -6,7 +6,7 @@ const REDOC_TEMPLATE: &str = r#"
 <!DOCTYPE html>
 <html>
   <head>
-    <title>OpenAPI Explorer</title>
+    <title>{:title}</title>
     <!-- needed for adaptive design -->
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -30,13 +30,14 @@ const REDOC_TEMPLATE: &str = r#"
 </html>
 "#;
 
-pub(crate) fn create_html(document: &str) -> String {
+pub(crate) fn create_html(title: &str, document: &str) -> String {
     REDOC_TEMPLATE
+        .replace("{:title}", title)
         .replace("{:script}", REDOC_JS)
         .replace("{:spec}", document)
 }
 
-pub(crate) fn create_endpoint(document: String) -> impl Endpoint + 'static {
-    let ui_html = create_html(&document);
+pub(crate) fn create_endpoint(title: String, document: String) -> impl Endpoint + 'static {
+    let ui_html = create_html(&title, &document);
     poem::Route::new().at("/", make_sync(move |_| Html(ui_html.clone())))
 }

--- a/poem-openapi/src/ui/rapidoc/mod.rs
+++ b/poem-openapi/src/ui/rapidoc/mod.rs
@@ -9,7 +9,7 @@ const RAPIDOC_TEMPLATE: &str = r#"
     <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
     <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
     <link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;600&family=Roboto+Mono&display=swap" rel="stylesheet">
-    <title>RapiDoc</title>
+    <title>{:title}</title>
     <script charset="UTF-8">{:script}</script>
 </head>
 </html>
@@ -39,14 +39,15 @@ const RAPIDOC_TEMPLATE: &str = r#"
 </body>
 "#;
 
-pub(crate) fn create_html(document: &str) -> String {
+pub(crate) fn create_html(title: &str, document: &str) -> String {
     RAPIDOC_TEMPLATE
+        .replace("{:title}", title)
         .replace("{:script}", RAPIDOC_JS)
         .replace("{:spec}", document)
 }
 
-pub(crate) fn create_endpoint(document: String) -> impl Endpoint {
-    let ui_html = create_html(&document);
+pub(crate) fn create_endpoint(title: String, document: String) -> impl Endpoint {
+    let ui_html = create_html(&title, &document);
     let oauth_receiver_html = OAUTH_RECEIVER_HTML.replace("{:script}", RAPIDOC_JS);
 
     poem::Route::new()

--- a/poem-openapi/src/ui/redoc/mod.rs
+++ b/poem-openapi/src/ui/redoc/mod.rs
@@ -6,7 +6,7 @@ const REDOC_TEMPLATE: &str = r#"
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Redoc</title>
+    <title>{:title}</title>
     <!-- needed for adaptive design -->
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -36,13 +36,14 @@ const REDOC_TEMPLATE: &str = r#"
 </html>
 "#;
 
-pub(crate) fn create_html(document: &str) -> String {
+pub(crate) fn create_html(title: &str, document: &str) -> String {
     REDOC_TEMPLATE
+        .replace("{:title}", title)
         .replace("{:script}", REDOC_JS)
         .replace("{:spec}", document)
 }
 
-pub(crate) fn create_endpoint(document: String) -> impl Endpoint {
-    let ui_html = create_html(&document);
+pub(crate) fn create_endpoint(title: String, document: String) -> impl Endpoint {
+    let ui_html = create_html(&title, &document);
     poem::Route::new().at("/", make_sync(move |_| Html(ui_html.clone())))
 }

--- a/poem-openapi/src/ui/scalar/mod.rs
+++ b/poem-openapi/src/ui/scalar/mod.rs
@@ -6,7 +6,7 @@ const SCALAR_TEMPLATE: &str = r#"
 <!doctype html>
 <html>
   <head>
-    <title>Scalar</title>
+    <title>{:title}</title>
     <meta charset="utf-8" />
     <meta
       name="viewport"
@@ -30,13 +30,14 @@ const SCALAR_TEMPLATE: &str = r#"
 </html>
 "#;
 
-pub(crate) fn create_html(document: &str) -> String {
+pub(crate) fn create_html(title: &str, document: &str) -> String {
     SCALAR_TEMPLATE
+        .replace("{:title}", title)
         .replace("{:script}", SCALAR_JS)
         .replace("{:spec}", document)
 }
 
-pub(crate) fn create_endpoint(document: String) -> impl Endpoint + 'static {
-    let ui_html = create_html(&document);
+pub(crate) fn create_endpoint(title: String, document: String) -> impl Endpoint + 'static {
+    let ui_html = create_html(&title, &document);
     poem::Route::new().at("/", make_sync(move |_| Html(ui_html.clone())))
 }

--- a/poem-openapi/src/ui/stoplight_elements/mod.rs
+++ b/poem-openapi/src/ui/stoplight_elements/mod.rs
@@ -2,11 +2,13 @@ use poem::{Endpoint, endpoint::make_sync, web::Html};
 
 const TEMPLATE: &str = include_str!("stoplight-elements.html");
 
-pub(crate) fn create_html(document: &str) -> String {
-    TEMPLATE.replace("'{:spec}'", document)
+pub(crate) fn create_html(title: &str, document: &str) -> String {
+    TEMPLATE
+        .replace("{:title}", title)
+        .replace("'{:spec}'", document)
 }
 
-pub(crate) fn create_endpoint(document: String) -> impl Endpoint {
-    let ui_html = create_html(&document);
+pub(crate) fn create_endpoint(title: String, document: String) -> impl Endpoint {
+    let ui_html = create_html(&title, &document);
     poem::Route::new().at("/", make_sync(move |_| Html(ui_html.clone())))
 }

--- a/poem-openapi/src/ui/stoplight_elements/stoplight-elements.html
+++ b/poem-openapi/src/ui/stoplight_elements/stoplight-elements.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-    <title>OpenAPI</title>
+    <title>{:title}</title>
     <!-- Embed elements Elements via Web Component -->
     <script src="https://unpkg.com/@stoplight/elements/web-components.min.js"></script>
     <link rel="stylesheet" href="https://unpkg.com/@stoplight/elements/styles.min.css" />

--- a/poem-openapi/src/ui/swagger_ui/mod.rs
+++ b/poem-openapi/src/ui/swagger_ui/mod.rs
@@ -8,7 +8,7 @@ const SWAGGER_UI_TEMPLATE: &str = r#"
 <html charset="UTF-8">
 <head>
     <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
-    <title>Swagger UI</title>
+    <title>{:title}</title>
     <style charset="UTF-8">{:style}</style>
     <script charset="UTF-8">{:script}</script>
 </head>
@@ -44,15 +44,16 @@ const SWAGGER_UI_TEMPLATE: &str = r#"
 </html>
 "#;
 
-pub(crate) fn create_html(document: &str) -> String {
+pub(crate) fn create_html(title: &str, document: &str) -> String {
     SWAGGER_UI_TEMPLATE
+        .replace("{:title}", title)
         .replace("{:style}", SWAGGER_UI_CSS)
         .replace("{:script}", SWAGGER_UI_JS)
         .replace("{:spec}", document)
 }
 
-pub(crate) fn create_endpoint(document: String) -> impl Endpoint {
-    let ui_html = create_html(&document);
+pub(crate) fn create_endpoint(title: String, document: String) -> impl Endpoint {
+    let ui_html = create_html(&title, &document);
     poem::Route::new()
         .at("/", make_sync(move |_| Html(ui_html.clone())))
         .at(


### PR DESCRIPTION
## Summary
- All OpenAPI UI endpoints now use the API title from `OpenApiService::new()` as the HTML page `<title>` instead of hardcoded values

## Changes
Updated all 6 UI modules to accept a `title` parameter:
- **Swagger UI**: `<title>Swagger UI</title>` → `<title>{api_title}</title>`
- **Scalar**: `<title>Scalar</title>` → `<title>{api_title}</title>`
- **Redoc**: `<title>Redoc</title>` → `<title>{api_title}</title>`
- **Rapidoc**: `<title>RapiDoc</title>` → `<title>{api_title}</title>`
- **OpenAPI Explorer**: `<title>OpenAPI Explorer</title>` → `<title>{api_title}</title>`
- **Stoplight Elements**: `<title>OpenAPI</title>` → `<title>{api_title}</title>`

## Example
```rust
let api_service = OpenApiService::new(Api, "My Pet Store API", "1.0.0");
// All UI pages will now have <title>My Pet Store API</title>
```

Closes #1073