### PR TITLE
Implement ToXML for Vec<T: ToJSON>

### DIFF
--- a/poem-openapi/src/types/external/vec.rs
+++ b/poem-openapi/src/types/external/vec.rs
@@ -7,7 +7,7 @@ use crate::{
     registry::{MetaSchema, MetaSchemaRef, Registry},
     types::{
         ParseError, ParseFromJSON, ParseFromMultipartField, ParseFromParameter, ParseResult,
-        ToJSON, Type,
+        ToJSON, ToXML, Type,
     },
 };
 
@@ -114,6 +114,12 @@ impl<T: ToJSON> ToJSON for Vec<T> {
             }
         }
         Some(Value::Array(values))
+    }
+}
+
+impl<T: ToJSON> ToXML for Vec<T> {
+    fn to_xml(&self) -> Option<Value> {
+        ToJSON::to_json(&self)
     }
 }
 


### PR DESCRIPTION
The trait `ToXML` wants to produce serde_json::Value values, which is why it makes sense to use the trait bound `ToJSON`. And given that there is already an `impl ToJSON for Vec<T: ToJSON>` I can just call that.

I would like to send XML payloads that contain arrays. It would be really nice if this was possible with poem-openapi.