### PR TITLE
fix(cookies): allow cookies and sessions to update on error

### DIFF
--- a/poem/src/middleware/cookie_jar_manager.rs
+++ b/poem/src/middleware/cookie_jar_manager.rs
@@ -57,7 +57,16 @@ impl<E: Endpoint> Endpoint for CookieJarManagerEndpoint<E> {
             let mut cookie_jar = CookieJar::extract_from_headers(req.headers());
             cookie_jar.key.clone_from(&self.key);
             req.state_mut().cookie_jar = Some(cookie_jar.clone());
-            let mut resp = self.inner.call(req).await?.into_response();
+            let mut resp = self
+                .inner
+                .call(req)
+                .await
+                .map_err(|err| {
+                    let mut resp = err.into_response();
+                    cookie_jar.append_delta_to_headers(resp.headers_mut());
+                    crate::Error::from_response(resp)
+                })?
+                .into_response();
             cookie_jar.append_delta_to_headers(resp.headers_mut());
             Ok(resp)
         } else {

--- a/poem/src/session/cookie_session.rs
+++ b/poem/src/session/cookie_session.rs
@@ -87,9 +87,8 @@ impl<E: Endpoint> Endpoint for CookieSessionEndpoint<E> {
             };
         };
 
-        let resp = self.inner.call(req).await.map_err(|err| {
+        let resp = self.inner.call(req).await.inspect_err(|_| {
             mutate();
-            err
         })?;
 
         mutate();

--- a/poem/src/session/cookie_session.rs
+++ b/poem/src/session/cookie_session.rs
@@ -64,27 +64,35 @@ impl<E: Endpoint> Endpoint for CookieSessionEndpoint<E> {
             .unwrap_or_default();
 
         req.extensions_mut().insert(session.clone());
-        let resp = self.inner.call(req).await?;
 
-        match session.status() {
-            SessionStatus::Changed | SessionStatus::Renewed => {
-                let value = {
-                    #[cfg(not(feature = "sonic-rs"))]
-                    {
-                        serde_json::to_string(&session.entries()).unwrap_or_default()
-                    }
-                    #[cfg(feature = "sonic-rs")]
-                    {
-                        sonic_rs::to_string(&session.entries()).unwrap_or_default()
-                    }
-                };
-                self.config.set_cookie_value(&cookie_jar, &value);
-            }
-            SessionStatus::Purged => {
-                self.config.remove_cookie(&cookie_jar);
-            }
-            SessionStatus::Unchanged => {}
+        let mutate = move || {
+            match session.status() {
+                SessionStatus::Changed | SessionStatus::Renewed => {
+                    let value = {
+                        #[cfg(not(feature = "sonic-rs"))]
+                        {
+                            serde_json::to_string(&session.entries()).unwrap_or_default()
+                        }
+                        #[cfg(feature = "sonic-rs")]
+                        {
+                            sonic_rs::to_string(&session.entries()).unwrap_or_default()
+                        }
+                    };
+                    self.config.set_cookie_value(&cookie_jar, &value);
+                }
+                SessionStatus::Purged => {
+                    self.config.remove_cookie(&cookie_jar);
+                }
+                SessionStatus::Unchanged => {}
+            };
         };
+
+        let resp = self.inner.call(req).await.map_err(|err| {
+            mutate();
+            err
+        })?;
+
+        mutate();
 
         Ok(resp)
     }


### PR DESCRIPTION
`CookieJar` and `Session` is not able to update cookies if the endpoint returned an error. It makes extractors returning Err cannot guarantee the session or cookie is updated (especially something like flash message).

This change will make cookies can be updated even an error is returned from endpoint