### PR TITLE
chore: Update quick-xml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ bytes = "1.1.0"
 futures-util = "0.3.17"
 tokio-stream = "0.1.8"
 serde_yaml = "0.9"
-quick-xml = { version = "0.36.1", features = ["serialize"] }
+quick-xml = { version = "0.42", features = ["serialize"] }
 base64 = "0.22.0"
 serde_urlencoded = "0.7.1"
 indexmap = "2.0.0"

--- a/poem/src/web/xml.rs
+++ b/poem/src/web/xml.rs
@@ -124,8 +124,8 @@ impl<'a, T: DeserializeOwned> FromRequest<'a> for Xml<T> {
 }
 
 fn is_xml_content_type(content_type: &str) -> bool {
-    matches!(content_type.parse::<mime::Mime>(), 
-        Ok(content_type) if content_type.type_() == "application" 
+    matches!(content_type.parse::<mime::Mime>(),
+        Ok(content_type) if content_type.type_() == "application"
         && (content_type.subtype() == "xml"
         || content_type
             .suffix()
@@ -137,7 +137,7 @@ impl<T: Serialize + Send> IntoResponse for Xml<T> {
         let data = match quick_xml::se::to_string(&self.0) {
             Ok(data) => data,
             Err(err) => match err {
-                quick_xml::DeError::Unsupported(_) => {
+                quick_xml::SeError::Unsupported(_) => {
                     match quick_xml::se::to_string_with_root("root", &self.0) {
                         Ok(data) => data,
                         Err(err) => {


### PR DESCRIPTION
Update the QuickXML dependency, especially so RUSTSEC-2026-0194 and RUSTSEC-2026-0195 are no longer hit.